### PR TITLE
ENH: `lift_subqueries` scheduler pass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+    - id: mixed-line-ending
+    - id: name-tests-test
+      args: ["--pytest-test-first"]
+    - id: no-commit-to-branch
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.8
+  hooks:
+    - id: ruff
+      args: ["--fix"]
+      types_or: [ python, pyi, jupyter ]
+    - id: ruff-format
+      types_or: [ python, pyi, jupyter ]

--- a/src/finch/autoschedule/__init__.py
+++ b/src/finch/autoschedule/__init__.py
@@ -14,7 +14,11 @@ from ..finch_logic import (
     Subquery,
     Table,
 )
-from .optimize import optimize, propagate_map_queries
+from .optimize import (
+    optimize,
+    propagate_map_queries,
+    lift_subqueries,
+)
 from ..symbolic import PostOrderDFS, PostWalk, PreWalk
 
 __all__ = [
@@ -34,6 +38,7 @@ __all__ = [
     "Table",
     "optimize",
     "propagate_map_queries",
+    "lift_subqueries",
     "PostOrderDFS",
     "PostWalk",
     "PreWalk",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,21 +1,93 @@
-from finch.autoschedule import propagate_map_queries
-from finch.finch_logic import *
+from finch.autoschedule import propagate_map_queries, lift_subqueries
+from finch.finch_logic import (
+    Plan,
+    Query,
+    Alias,
+    Aggregate,
+    Immediate,
+    MapJoin,
+    Produces,
+    Subquery,
+)
 
 
 def test_propagate_map_queries_simple():
     plan = Plan(
         (
-            Query(Alias("A10"), Aggregate(Immediate("+"), Immediate(0), Immediate("[1,2,3]"), ())),
+            Query(
+                Alias("A10"),
+                Aggregate(Immediate("+"), Immediate(0), Immediate("[1,2,3]"), ()),
+            ),
             Query(Alias("A11"), Alias("A10")),
-            Produces((Alias("11"),)),
+            Produces((Alias("A11"),)),
         )
     )
     expected = Plan(
         (
-            Query(Alias("A11"), MapJoin(Immediate("+"), (Immediate(0), Immediate("[1,2,3]")))),
-            Produces((Alias("11"),)),
+            Query(
+                Alias("A11"),
+                MapJoin(Immediate("+"), (Immediate(0), Immediate("[1,2,3]"))),
+            ),
+            Produces((Alias("A11"),)),
         )
     )
 
     result = propagate_map_queries(plan)
+    assert result == expected
+
+
+def test_lift_subqueries():
+    plan = Plan(
+        (
+            Query(
+                Alias("A10"),
+                Plan(
+                    (
+                        Subquery(Alias("C10"), Immediate(0)),
+                        Subquery(
+                            Alias("B10"),
+                            MapJoin(
+                                Immediate("+"),
+                                (
+                                    Subquery(Alias("C10"), Immediate(0)),
+                                    Immediate("[1,2,3]"),
+                                ),
+                            ),
+                        ),
+                        Subquery(Alias("B10"), Immediate(0)),
+                        Produces((Alias("B10"),)),
+                    )
+                ),
+            ),
+            Produces((Alias("A10"),)),
+        )
+    )
+
+    expected = Plan(
+        (
+            Plan(
+                (
+                    Query(Alias("C10"), Immediate(0)),
+                    Query(
+                        Alias("B10"),
+                        MapJoin(Immediate("+"), (Alias("C10"), Immediate("[1,2,3]"))),
+                    ),
+                    Query(
+                        Alias("A10"),
+                        Plan(
+                            (
+                                Alias("C10"),
+                                Alias("B10"),
+                                Alias("B10"),
+                                Produces((Alias("B10"),)),
+                            )
+                        ),
+                    ),
+                ),
+            ),
+            Produces((Alias("A10"),)),
+        )
+    )
+
+    result = lift_subqueries(plan)
     assert result == expected


### PR DESCRIPTION
This PR:
- introduces `lift_subqueries` default scheduler pass
- adds `pre-commit` setup
- lints existing files according to `ruff` rules
