### PR TITLE
ENH: Add `propagate_fields` pass and `get_fields` method to LogicNode

### DIFF
--- a/src/finch/autoschedule/__init__.py
+++ b/src/finch/autoschedule/__init__.py
@@ -16,6 +16,7 @@ from ..finch_logic import (
 )
 from .optimize import (
     optimize,
+    propagate_fields,
     propagate_map_queries,
     lift_subqueries,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "Subquery",
     "Table",
     "optimize",
+    "propagate_fields",
     "propagate_map_queries",
     "lift_subqueries",
     "PostOrderDFS",

--- a/src/finch/autoschedule/optimize.py
+++ b/src/finch/autoschedule/optimize.py
@@ -1,3 +1,5 @@
+from typing import Any, Iterable
+
 from .compiler import LogicCompiler
 from ..finch_logic import (
     Aggregate,
@@ -7,6 +9,7 @@ from ..finch_logic import (
     Plan,
     Produces,
     Query,
+    Relabel,
     Subquery,
 )
 from ..symbolic import Chain, PostOrderDFS, PostWalk, PreWalk, Rewrite
@@ -87,6 +90,30 @@ def propagate_map_queries(root: LogicNode) -> LogicNode:
 
     root = Rewrite(PreWalk(Chain([rule_0, rule_1])))(root)
     return Rewrite(PostWalk(rule_2))(root)
+
+
+def _propagate_fields(
+    root: LogicNode, fields: dict[LogicNode, Iterable[LogicNode]]
+) -> LogicNode:
+    match root:
+        case Plan(bodies):
+            return Plan(tuple(_propagate_fields(b, fields) for b in bodies))
+        case Query(lhs, rhs):
+            rhs = _propagate_fields(rhs, fields)
+            fields[lhs] = rhs.get_fields()
+            return Query(lhs, rhs)
+        case Alias() as a:
+            return Relabel(a, tuple(fields[a]))
+        case node if node.is_expr():
+            return node.make_term(
+                node.head(), *[_propagate_fields(c, fields) for c in node.children()]
+            )
+        case node:
+            return node
+
+
+def propagate_fields(root: LogicNode) -> LogicNode:
+    return _propagate_fields(root, fields={})
 
 
 class DefaultLogicOptimizer:

--- a/src/finch/symbolic/rewriters.py
+++ b/src/finch/symbolic/rewriters.py
@@ -20,13 +20,15 @@ Classes:
     Memo: Caches the results of a rewriter to avoid redundant computations.
 """
 
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable
 from .term import Term
 
 RwCallable = Callable[[Term], Term | None]
 
+
 def default_rewrite(x: Term | None, y: Term) -> Term:
     return x if x is not None else y
+
 
 class Rewrite:
     """
@@ -35,11 +37,13 @@ class Rewrite:
     Attributes:
         rw (RwCallable): The rewriter function to apply.
     """
+
     def __init__(self, rw: RwCallable):
         self.rw = rw
 
     def __call__(self, x: Term) -> Term:
         return default_rewrite(self.rw(x), x)
+
 
 class PreWalk:
     """
@@ -50,6 +54,7 @@ class PreWalk:
     Attributes:
         rw (RwCallable): The rewriter function to apply.
     """
+
     def __init__(self, rw: RwCallable):
         self.rw = rw
 
@@ -58,13 +63,18 @@ class PreWalk:
         if y is not None:
             if y.is_expr():
                 args = y.children()
-                return y.make_term(y.head(), *[default_rewrite(self(arg), arg) for arg in args])
+                return y.make_term(
+                    y.head(), *[default_rewrite(self(arg), arg) for arg in args]
+                )
             return y
         if x.is_expr():
             args = x.children()
             new_args = list(map(self, args))
             if not all(arg is None for arg in new_args):
-                return x.make_term(x.head(), *map(lambda x1, x2: default_rewrite(x1, x2), new_args, args))
+                return x.make_term(
+                    x.head(),
+                    *map(lambda x1, x2: default_rewrite(x1, x2), new_args, args),
+                )
             return None
         return None
 
@@ -78,6 +88,7 @@ class PostWalk:
     Attributes:
         rw (RwCallable): The rewriter function to apply.
     """
+
     def __init__(self, rw: RwCallable):
         self.rw = rw
 
@@ -87,9 +98,12 @@ class PostWalk:
             new_args = list(map(self, args))
             if all(arg is None for arg in new_args):
                 return self.rw(x)
-            y = x.make_term(x.head(), *map(lambda x1, x2: default_rewrite(x1, x2), new_args, args))
+            y = x.make_term(
+                x.head(), *map(lambda x1, x2: default_rewrite(x1, x2), new_args, args)
+            )
             return default_rewrite(self.rw(y), y)
         return self.rw(x)
+
 
 class Chain:
     """
@@ -99,6 +113,7 @@ class Chain:
     Attributes:
         rws (Iterable[RwCallable]): A collection of rewriter functions to apply.
     """
+
     def __init__(self, rws: Iterable[RwCallable]):
         self.rws = rws
 
@@ -113,6 +128,7 @@ class Chain:
             return x
         return None
 
+
 class Fixpoint:
     """
     A rewriter which repeatedly applies `rw` to `x` until no changes are made. If
@@ -121,6 +137,7 @@ class Fixpoint:
     Attributes:
         rw (RwCallable): The rewriter function to apply.
     """
+
     def __init__(self, rw: RwCallable):
         self.rw = rw
 
@@ -130,8 +147,10 @@ class Fixpoint:
             while y is not None and x != y:
                 x = y
                 y = self.rw(x)
+            return x
         else:
             return None
+
 
 class Prestep:
     """
@@ -141,6 +160,7 @@ class Prestep:
     Attributes:
         rw (RwCallable): The rewriter function to apply.
     """
+
     def __init__(self, rw: RwCallable):
         self.rw = rw
 
@@ -149,9 +169,12 @@ class Prestep:
         if y is not None:
             if y.is_expr():
                 y_args = y.children()
-                return y.make_term(y.head(), *[default_rewrite(self(arg), arg) for arg in y_args])
+                return y.make_term(
+                    y.head(), *[default_rewrite(self(arg), arg) for arg in y_args]
+                )
             return y
         return None
+
 
 class Memo:
     """
@@ -162,6 +185,7 @@ class Memo:
         rw (RwCallable): The rewriter function to apply.
         cache (dict): A dictionary to store cached results.
     """
+
     def __init__(self, rw: RwCallable, cache: dict = None):
         self.rw = rw
         self.cache = cache if cache is not None else {}
@@ -170,13 +194,3 @@ class Memo:
         if x not in self.cache:
             self.cache[x] = self.rw(x)
         return self.cache[x]
-
-
-
-
-
-
-
-
-
-

--- a/src/finch/symbolic/term.py
+++ b/src/finch/symbolic/term.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
+from typing import Any, Iterator
 from abc import ABC, abstractmethod
+
 """
 This module contains definitions for common functions that are useful for symbolic expression manipulation.
 Its purpose is to provide a shared interface between various symbolic programming in Finch.
@@ -8,7 +9,7 @@ Classes:
     Term (ABC): An abstract base class representing a symbolic term. It provides methods to access the head
     of the term, its children, and to construct a new term with a similar structure.
 """
-from typing import Any, List
+
 
 class Term(ABC):
     def __init__(self):
@@ -19,7 +20,7 @@ class Term(ABC):
         """Return the head type of the S-expression."""
         pass
 
-    def children(self) -> List[Term]:
+    def children(self) -> list["Term"]:
         """Return the children (AKA tail) of the S-expression."""
         pass
 
@@ -29,27 +30,31 @@ class Term(ABC):
         pass
 
     @abstractmethod
-    def make_term(self, head: Any, children: List[Term]) -> Term:
+    def make_term(self, head: Any, children: list["Term"]) -> "Term":
         """
-            Construct a new term in the same family of terms with the given head type and children.
-            This function should satisfy `x == x.make_term(x.head(), *x.children())`
+        Construct a new term in the same family of terms with the given head type and children.
+        This function should satisfy `x == x.make_term(x.head(), *x.children())`
         """
         pass
 
     def __hash__(self) -> int:
         """Return the hash value of the term."""
         if self._hashcache is None:
-            self._hashcache = hash((0x1ca5c2adca744860, self.head(), tuple(self.children())))
+            self._hashcache = hash(
+                (0x1CA5C2ADCA744860, self.head(), tuple(self.children()))
+            )
         return self._hashcache
 
-    def __eq__(self, other: Term) -> bool:
+    def __eq__(self, other: "Term") -> bool:
         self.head() == other.head() and self.children() == other.children()
+
 
 def PostOrderDFS(node: Term) -> Iterator[Term]:
     if node.is_expr():
         for arg in node.children():
             yield from PostOrderDFS(arg)
     yield node
+
 
 def PreOrderDFS(node: Term) -> Iterator[Term]:
     yield node


### PR DESCRIPTION
This PR:

- Introduces `get_fields` method to LogicNode that is required by multiple passes.
- Introduces `propagate_fields` pass.
- Fixes `Fixpoint` rewrite class.
- Adds `make_term` to remaining classes.
- Applies formatting to remaining files.
