### PR TITLE
Test `with_subsequence`, `is_subsequence`, and `intersect`

### DIFF
--- a/src/finch/autoschedule/_utils.py
+++ b/src/finch/autoschedule/_utils.py
@@ -1,0 +1,14 @@
+def intersect(x1: tuple, x2: tuple) -> tuple:
+    return tuple(x for x in x1 if x in x2)
+
+
+def is_subsequence(x1: tuple, x2: tuple) -> bool:
+    return x1 == tuple(x for x in x2 if x in x1)
+
+
+def with_subsequence(x1: tuple, x2: tuple) -> tuple:
+    res = list(x2)
+    indices = [idx for idx, val in enumerate(x2) if val in x1]
+    for idx, i in enumerate(indices):
+        res[i] = x1[idx]
+    return tuple(res)

--- a/src/finch/autoschedule/compiler.py
+++ b/src/finch/autoschedule/compiler.py
@@ -15,6 +15,7 @@ from ..finch_logic import (
     Subquery,
     Table,
 )
+from ._utils import intersect, with_subsequence
 
 
 def get_or_insert(
@@ -87,18 +88,6 @@ def compile_logic_constant(ex: LogicNode) -> str:
             return f":({ex}::{type_})"
         case _:
             raise Exception(f"Invalid constant: {ex}")
-
-
-def intersect(x1: tuple, x2: tuple) -> tuple:
-    return tuple(x for x in x1 if x in x2)
-
-
-def with_subsequence(x1: tuple, x2: tuple) -> tuple:
-    res = list(x2)
-    indices = [idx for idx, val in enumerate(x2) if val in x1]
-    for idx, i in enumerate(indices):
-        res[i] = x1[idx]
-    return tuple(res)
 
 
 class LogicLowerer:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+import pytest
+
+from finch.autoschedule._utils import intersect, is_subsequence, with_subsequence
+from finch.finch_logic import Field
+
+
+@pytest.fixture
+def tp_0():
+    return (Field("A1"), Field("A3"))
+
+
+@pytest.fixture
+def tp_1():
+    return (Field("A0"), Field("A1"), Field("A2"), Field("A3"))
+
+
+@pytest.fixture
+def tp_2():
+    return (Field("A3"), Field("A1"))
+
+
+@pytest.fixture
+def tp_3():
+    return (Field("A0"), Field("A3"), Field("A2"), Field("A1"))
+
+
+def test_intersect(tp_0, tp_1, tp_2, tp_3):
+    assert intersect(tp_1, tp_2) == tp_0
+    assert intersect(tp_3, tp_1) == tp_3
+
+
+def test_with_subsequence(tp_0, tp_1, tp_2, tp_3):
+    assert with_subsequence(tp_2, tp_1) == tp_3
+    assert with_subsequence(tp_0, tp_1) == tp_1
+    assert with_subsequence(tp_3, tp_1) == tp_3
+
+
+def test_is_subsequence(tp_0, tp_1, tp_2, tp_3):
+    assert not is_subsequence(tp_2, tp_1)
+    assert is_subsequence(tp_0, tp_1)
+    assert not is_subsequence(tp_3, tp_1)


### PR DESCRIPTION
Hi @willow-ahrens,

There's something that still bugs me about `with_subsequence` and `issubsequence`.

Here I simplified `with_subsequence` removing one `enumerate`, as:
```python
indices = [idx for idx, _ in enumerate(sth)]
for idx, i in enumerate(indices):
    ...
```
will always be the same as:
```python
indices = [idx for idx, _ in enumerate(sth)]
for idx, in indices:
    i = idx
    ...
```

`enumerate()` here always starts at 0 so there's no possibility that `idx` will differ from `i`.

Another thing is that, in my opinion `with_subsequence(x1, x2) == x2` regardless of inputs. We have `if val in x1` where `val` comes from `x2` at `idx`, and then we insert it at `idx` to `res`, so it eventually ends up identical as `x2` (`val`s are instances of dataclasses, mostly `Field`s I guess).

A test case where `with_subsequence(x1, x2) != x2` would help me understand it better, whether I'm missing something.

---

Same goes for `!issubsequence(intersect(idxs_1, idxs_2), idxs_2)`. I see that it's present in one of the rules in `push_fields` - I didn't port it yet, because I can't think of an example where it evaluates to true. 