### PR TITLE
Wma/fix64

### DIFF
--- a/src/finch/interface/lazy.py
+++ b/src/finch/interface/lazy.py
@@ -395,7 +395,7 @@ def elementwise(f: Callable, *args) -> LazyTensor:
                     raise ValueError("Invalid shape for broadcasting")
                 idims.append(Field(gensym("j")))
         bargs.append(Reorder(Relabel(arg.data, tuple(idims)), tuple(odims)))
-    data = MapJoin(Immediate(f), tuple(bargs))
+    data = Reorder(MapJoin(Immediate(f), tuple(bargs)), idxs)
     new_fill_value = f(*[x.fill_value for x in args])
     new_element_type = return_type(f, *[x.element_type for x in args])
     return LazyTensor(identify(data), shape, new_fill_value, new_element_type)

--- a/src/finch/interface/lazy.py
+++ b/src/finch/interface/lazy.py
@@ -381,7 +381,7 @@ def elementwise(f: Callable, *args) -> LazyTensor:
         )
         for i in range(ndim)
     )
-    idxs = [Field(gensym("i")) for _ in range(ndim)]
+    idxs = tuple(Field(gensym("i")) for _ in range(ndim))
     bargs = []
     for arg in args:
         idims = []

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,10 +1,11 @@
-import pytest
 import numpy as np
+
 import finch
 
+
 def test_issue_64():
-    a = finch.defer(np.arange(1*2).reshape(1, 2, 1))
-    b = finch.defer(np.arange(4*2*3).reshape(4, 2, 3))
+    a = finch.defer(np.arange(1 * 2).reshape(1, 2, 1))
+    b = finch.defer(np.arange(4 * 2 * 3).reshape(4, 2, 3))
 
     c = finch.multiply(a, b)
     result = finch.compute(c).shape

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,0 +1,12 @@
+import pytest
+import numpy as np
+import finch
+
+def test_issue_64():
+    a = finch.defer(np.arange(1*2).reshape(1, 2, 1))
+    b = finch.defer(np.arange(4*2*3).reshape(4, 2, 3))
+
+    c = finch.multiply(a, b)
+    result = finch.compute(c).shape
+    expected = (4, 2, 3)
+    assert result == expected, f"Expected shape {expected}, got {result}"


### PR DESCRIPTION
fixes #64

 we drop 1 dimensions before mapjoining them together, since FinchLogic requires explicit broadcast. However, due to the field ordering algorithm of Mapjoin, the output field order may not be correct after that. I added a reorder to fix it.