### PR TITLE
fix handling of formats

### DIFF
--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -71,7 +71,7 @@ __all__ = [
     "fill_value",
     "element_type",
     "CKernel",
-    "AbstractBuffer",
+    "Buffer",
     "NumpyBuffer",
     "NumpyBufferFormat",
     "min",

--- a/src/finch/codegen/__init__.py
+++ b/src/finch/codegen/__init__.py
@@ -1,12 +1,12 @@
-from .c import AbstractCArgument, AbstractCFormat, CCompiler, CKernel, CModule
+from .c import CArgument, CBufferFormat, CCompiler, CKernel, CModule
 from .numpy_buffer import NumpyBuffer, NumpyBufferFormat
 
 __all__ = [
     "CKernel",
     "CModule",
     "CCompiler",
-    "AbstractCArgument",
-    "AbstractCFormat",
+    "CArgument",
+    "CBufferFormat",
     "NumpyBuffer",
     "NumpyBufferFormat",
 ]

--- a/src/finch/codegen/c.py
+++ b/src/finch/codegen/c.py
@@ -14,8 +14,8 @@ import numpy as np
 
 from .. import finch_assembly as asm
 from ..algebra import query_property, register_property
-from ..finch_assembly.abstract_buffer import AbstractFormat, isinstanceorformat
-from ..symbolic import AbstractContext, ScopedDict
+from ..finch_assembly.abstract_buffer import BufferFormat
+from ..symbolic import AbstractContext, ScopedDict, has_format
 from ..util import config
 from ..util.cache import file_cache
 
@@ -90,7 +90,7 @@ def load_shared_lib(c_code, cc=None, cflags=None):
     return ctypes.CDLL(str(shared_lib_path))
 
 
-class AbstractCArgument(ABC):
+class CArgument(ABC):
     @abstractmethod
     def serialize_to_c(self, name):
         """
@@ -129,13 +129,13 @@ class CKernel:
                 f"Expected {len(self.argtypes)} arguments, got {len(args)}"
             )
         for argtype, arg in zip(self.argtypes, args, strict=False):
-            if not isinstanceorformat(arg, argtype):
+            if not has_format(arg, argtype):
                 raise TypeError(f"Expected argument of type {argtype}, got {type(arg)}")
         serial_args = list(map(methodcaller("serialize_to_c"), args))
         res = self.c_function(*serial_args)
         for arg, serial_arg in zip(args, serial_args, strict=False):
             arg.deserialize_from_c(serial_arg)
-        if isinstanceorformat(res, self.ret_type):
+        if has_format(res, self.ret_type):
             return res
         if self.ret_type is type(None):
             return None
@@ -682,10 +682,10 @@ class CContext(AbstractContext):
                 )
 
 
-class AbstractCFormat(AbstractFormat, ABC):
+class CBufferFormat(BufferFormat, ABC):
     """
     Abstract base class for the format of datastructures. The format defines how
-    the data in an AbstractBuffer is organized and accessed.
+    the data in an Buffer is organized and accessed.
     """
 
     @abstractmethod

--- a/src/finch/codegen/numpy_buffer.py
+++ b/src/finch/codegen/numpy_buffer.py
@@ -2,8 +2,8 @@ import ctypes
 
 import numpy as np
 
-from ..finch_assembly.abstract_buffer import AbstractBuffer
-from .c import AbstractCArgument, AbstractCFormat, c_type
+from ..finch_assembly.abstract_buffer import Buffer
+from .c import CArgument, CBufferFormat, c_type
 
 
 @ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.POINTER(ctypes.py_object), ctypes.c_size_t)
@@ -25,10 +25,10 @@ class NumpyCBuffer(ctypes.Structure):
     ]
 
 
-class NumpyBuffer(AbstractBuffer, AbstractCArgument):
+class NumpyBuffer(Buffer, CArgument):
     """
     A buffer that uses NumPy arrays to store data. This is a concrete implementation
-    of the AbstractBuffer class.
+    of the Buffer class.
     """
 
     def __init__(self, arr: np.ndarray):
@@ -71,10 +71,10 @@ class NumpyBuffer(AbstractBuffer, AbstractCArgument):
         """
 
 
-class NumpyBufferFormat(AbstractCFormat):
+class NumpyBufferFormat(CBufferFormat):
     """
     A format for buffers that uses NumPy arrays. This is a concrete implementation
-    of the AbstractBufferFormat class.
+    of the BufferFormat class.
     """
 
     def __init__(self, dtype: type):

--- a/src/finch/finch_assembly/__init__.py
+++ b/src/finch/finch_assembly/__init__.py
@@ -1,4 +1,4 @@
-from .abstract_buffer import AbstractBuffer, AbstractFormat, isinstanceorformat
+from .abstract_buffer import Buffer, BufferFormat
 from .interpreter import AssemblyInterpreter, AssemblyInterpreterKernel
 from .nodes import (
     AssemblyNode,
@@ -42,9 +42,9 @@ __all__ = [
     "Module",
     "If",
     "IfElse",
-    "AbstractBuffer",
-    "AbstractFormat",
+    "Buffer",
+    "BufferFormat",
     "AssemblyInterpreter",
     "AssemblyInterpreterKernel",
-    "isinstanceorformat",
+    "has_format",
 ]

--- a/src/finch/finch_assembly/abstract_buffer.py
+++ b/src/finch/finch_assembly/abstract_buffer.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 
+from ..symbolic import Format, Formattable
 
-class AbstractBuffer(ABC):
+
+class Buffer(Formattable, ABC):
     """
     Abstract base class for buffer-like data structures. Buffers support random access,
     and can be resized. They are used to store data in a way that allows for efficient
@@ -56,7 +58,7 @@ class AbstractBuffer(ABC):
         ...
 
 
-class AbstractFormat(ABC):
+class BufferFormat(Format):
     """
     Abstract base class for the format of arguments. The format defines how the
     data structures store data, and can construct a data structure with the call method.
@@ -84,12 +86,3 @@ class AbstractFormat(ABC):
         Returns the type used for the length of the buffer.
         """
         return int
-
-
-def isinstanceorformat(x, format_or_type):
-    """
-    Check if x is an instance of the given format or type.
-    """
-    if isinstance(format_or_type, AbstractFormat):
-        return hasattr(x, "get_format") and x.get_format() == format_or_type
-    return isinstance(x, format_or_type)

--- a/src/finch/finch_assembly/interpreter.py
+++ b/src/finch/finch_assembly/interpreter.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from ..symbolic import ScopedDict
+from ..symbolic import ScopedDict, has_format
 from . import nodes as asm
-from .abstract_buffer import isinstanceorformat
 
 
 class AssemblyInterpreterKernel:
@@ -220,7 +219,7 @@ class AssemblyInterpreter:
                     for arg, arg_e in zip(args, args_e, strict=False):
                         match arg:
                             case asm.Variable(arg_n, arg_t):
-                                if not isinstanceorformat(arg_e, arg_t):
+                                if not has_format(arg_e, arg_t):
                                     raise TypeError(
                                         f"Argument '{arg_n}' is expected to be of type "
                                         f"{arg_t}, but got {type(arg_e)}."

--- a/src/finch/symbolic/__init__.py
+++ b/src/finch/symbolic/__init__.py
@@ -1,4 +1,5 @@
 from .environment import AbstractContext, AbstractSymbolic, Namespace, ScopedDict
+from .format import Format, Formattable, has_format
 from .gensym import gensym
 from .rewriters import (
     Chain,
@@ -29,4 +30,7 @@ __all__ = [
     "AbstractContext",
     "AbstractSymbolic",
     "ScopedDict",
+    "Format",
+    "Formattable",
+    "has_format",
 ]

--- a/src/finch/symbolic/format.py
+++ b/src/finch/symbolic/format.py
@@ -1,0 +1,33 @@
+from abc import ABC, abstractmethod
+
+class Format(ABC):
+    @abstractmethod
+    def __eq__(self, other):
+        ...
+
+    @abstractmethod
+    def __hash__(self):
+        ...
+
+    def has_format(self, other):
+        """
+        Check if `other` is an instance of this format.
+        """
+        return other.get_format() == self
+
+
+class Formattable(ABC):
+    @abstractmethod
+    def get_format(self):
+        """
+        Get the format of the object.
+        """
+        ...
+
+def has_format(x, f):
+    """
+    Check if `x` is an instance of `f`.
+    """
+    if isinstance(f, type):
+        return isinstance(x, f)
+    return f.has_format(x)


### PR DESCRIPTION
Formats serve as types in many places in the compiler. I'd like to formalize this notion a little bit and move it into symbolic.py