### PR TITLE
Changes user-facing assertions to proper errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,12 @@ tests:
 ```bash
 poetry run pytest
 ```
+
+#### Optional Static Type Checking
+
+The pytest will run mypy to check for type errors, so you shouldn't need to run it manually.
+In case you do need to run mypy manually, you can do so with:
+
+```bash
+poetry run mypy ./src/
+```

--- a/src/finch/README.md
+++ b/src/finch/README.md
@@ -1,0 +1,45 @@
+# Finch Tensor: Developer README
+
+> **Note:** This README is AI-generated and may contain errors or omissions. If you find any inaccuracies or improvements, please update this file for the benefit of all contributors.
+
+## Overview
+
+This directory contains the implementation for Finch.py, a tensor compiler and runtime designed for extensibility and integration with other frameworks (such as NumPy). The codebase is organized to support both eager and lazy tensor computation, algebraic rewrites, and custom user extensions.
+
+## Directory Structure
+
+- `algebra/` — Algebraic properties, type promotion, and operator logic. Use this to define, register, and query custom properties for classes and operators.
+- `interface/` — User-facing tensor APIs, including lazy and eager tensor implementations. The aim is to provide a consistent interface for tensor operations according to the [array API specification](https://data-apis.org/array-api/latest/).
+- `symbolic/` — Symbolic utilities for tensor computation.
+- `finch_logic/` — Internal logic node representations and manipulation.
+- `overrides.py` — Mechanisms for user and library overrides.
+- `__init__.py` — Module initialization and exports.
+
+## Contributing
+
+- **If you find an error or unclear section in this README or the code, please fix it or open an issue.**
+- Follow the code style and conventions used throughout the project.
+- Add or update docstrings for all public functions and classes.
+- To to write thorough tests for new features and bug fixes in the `tests/` directory.
+
+## Assertions and Validation
+
+- **Do not use `assert` statements for user-facing validation.**
+    - Relying on `assert` for input validation or error checking is unsafe, as all `assert` statements are removed when Python is run with the `-O` (optimize) flag, which may be used for production builds.
+    - Use explicit error handling (e.g., `if ...: raise ValueError(...)`) for all user-facing checks and input validation. For user facing APIs, you should raise exceptions according to the [array API specification](https://data-apis.org/array-api/latest/).
+- `assert` statements **may** be used for internal debugging, invariants, and sanity checks that are not critical for production correctness.
+
+## Testing
+
+- Tests are located in the `tests/` directory at the project root.
+- Use `poetry run pytest` to run the test suite.
+- Add tests for all new features and bug fixes.
+
+## Documentation
+
+- All public APIs should have clear docstrings following the NumPy style.
+- Update this README as the codebase evolves.
+
+---
+
+*This file is mostly AI-generated. Please help improve it as you work on the project!*

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -1,6 +1,5 @@
 from .algebra import element_type, fill_value
 from .codegen import (
-    CKernel,
     NumpyBuffer,
     NumpyBufferFormat,
 )
@@ -23,6 +22,8 @@ from .interface import (
     floordiv,
     fuse,
     fused,
+    matmul,
+    matrix_transpose,
     max,
     min,
     mod,
@@ -36,7 +37,9 @@ from .interface import (
     squeeze,
     subtract,
     sum,
+    tensordot,
     truediv,
+    vecdot,
 )
 
 __all__ = [
@@ -57,6 +60,12 @@ __all__ = [
     "abs",
     "positive",
     "negative",
+    "EagerTensor",
+    "LazyTensor",
+    "fill_value",
+    "element_type",
+    "matmul",
+    "matrix_transpose",
     "bitwise_and",
     "bitwise_or",
     "bitwise_xor",
@@ -66,12 +75,9 @@ __all__ = [
     "floordiv",
     "mod",
     "pow",
-    "EagerTensor",
+    "tensordot",
+    "vecdot",
     "LazyTensor",
-    "fill_value",
-    "element_type",
-    "CKernel",
-    "Buffer",
     "NumpyBuffer",
     "NumpyBufferFormat",
     "min",

--- a/src/finch/algebra/__init__.py
+++ b/src/finch/algebra/__init__.py
@@ -15,6 +15,7 @@ from .algebra import (
     shape_type,
 )
 from .operator import (
+    conjugate,
     promote_max,
     promote_min,
 )
@@ -36,4 +37,5 @@ __all__ = [
     "register_property",
     "promote_min",
     "promote_max",
+    "conjugate",
 ]

--- a/src/finch/algebra/operator.py
+++ b/src/finch/algebra/operator.py
@@ -27,6 +27,35 @@ def promote_max(a, b):
     return max(cast(a), cast(b))
 
 
+def conjugate(x):
+    """
+    Computes the complex conjugate of the input number
+
+    Parameters
+    ----------
+    x: Any
+        The input number to compute the complex conjugate of.
+
+    Returns
+    ----------
+    Any
+        The complex conjugate of the input number. If the input is not a complex number,
+        it returns the input unchanged.
+    """
+    if hasattr(x, "conjugate"):
+        return x.conjugate()
+    return x
+
+
+# register the conjugate operation return type. The conjugate operation
+# preserves the element type of the input tensor.
+algebra.register_property(
+    conjugate,
+    "__call__",
+    "return_type",
+    lambda obj, x: x,
+)
+
 algebra.register_property(
     promote_min,
     "__call__",

--- a/src/finch/interface/__init__.py
+++ b/src/finch/interface/__init__.py
@@ -12,6 +12,8 @@ from .eager import (
     elementwise,
     expand_dims,
     floordiv,
+    matmul,
+    matrix_transpose,
     max,
     min,
     mod,
@@ -25,7 +27,9 @@ from .eager import (
     squeeze,
     subtract,
     sum,
+    tensordot,
     truediv,
+    vecdot,
 )
 
 # from .tensor import *
@@ -54,6 +58,8 @@ __all__ = [
     "max",
     "EagerTensor",
     "LazyTensor",
+    "matmul",
+    "matrix_transpose",
     "bitwise_and",
     "bitwise_or",
     "bitwise_xor",
@@ -63,6 +69,8 @@ __all__ = [
     "floordiv",
     "mod",
     "pow",
+    "tensordot",
+    "vecdot",
     "any",
     "all",
 ]

--- a/src/finch/interface/eager.py
+++ b/src/finch/interface/eager.py
@@ -1,7 +1,7 @@
 import builtins
 import sys
 from abc import ABC
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 from . import lazy
 from .fuse import compute
@@ -205,6 +205,27 @@ def negative(x):
     return compute(lazy.negative(x))
 
 
+def matmul(x1, x2, /):
+    """
+    Computes the matrix product.
+
+    Returns a LazyTensor if either x1 or x2 is a LazyTensor.
+    Otherwise, computes the result eagerly.
+    """
+    if isinstance(x1, lazy.LazyTensor) or isinstance(x2, lazy.LazyTensor):
+        return lazy.matmul(x1, x2)
+    return compute(lazy.matmul(x1, x2))
+
+
+def matrix_transpose(x, /):
+    """
+    Computes the transpose of a matrix or stack of matrices.
+    """
+    if isinstance(x, lazy.LazyTensor):
+        return lazy.matrix_transpose(x)
+    return compute(lazy.matrix_transpose(x))
+
+
 def bitwise_and(x1, x2):
     if isinstance(x1, lazy.LazyTensor) or isinstance(x2, lazy.LazyTensor):
         return lazy.bitwise_and(x1, x2)
@@ -257,6 +278,41 @@ def pow(x1, x2):
     if isinstance(x1, lazy.LazyTensor) or isinstance(x2, lazy.LazyTensor):
         return lazy.pow(x1, x2)
     return compute(lazy.pow(x1, x2))
+
+
+def tensordot(x1, x2, /, *, axes: int | tuple[Sequence[int], Sequence[int]]):
+    """
+    Computes the tensordot operation.
+
+    Returns a LazyTensor if either x1 or x2 is a LazyTensor.
+    Otherwise, computes the result eagerly.
+    """
+    if isinstance(x1, lazy.LazyTensor) or isinstance(x2, lazy.LazyTensor):
+        return lazy.tensordot(x1, x2, axes=axes)
+    return compute(lazy.tensordot(x1, x2, axes=axes))
+
+
+def vecdot(x1, x2, /, *, axis=-1):
+    """
+    Computes the (vector) dot product of two arrays.
+
+    Parameters
+    ----------
+    x1: array
+        The first input tensor.
+    x2: array
+        The second input tensor.
+    axis: int, optional
+        The axis along which to compute the dot product. Default is -1 (last axis).
+
+    Returns
+    -------
+    out: array
+        A tensor containing the dot product of `x1` and `x2` along the specified axis.
+    """
+    if isinstance(x1, lazy.LazyTensor) or isinstance(x2, lazy.LazyTensor):
+        return lazy.vecdot(x1, x2, axis=axis)
+    return compute(lazy.vecdot(x1, x2, axis=axis))
 
 
 def any(x, /, *, axis: int | tuple[int, ...] | None = None, keepdims: bool = False):

--- a/src/finch/interface/fuse.py
+++ b/src/finch/interface/fuse.py
@@ -1,13 +1,3 @@
-from ..finch_logic import (
-    Alias,
-    FinchLogicInterpreter,
-    Plan,
-    Produces,
-    Query,
-)
-from ..symbolic import gensym
-from .lazy import defer
-
 """
 This module provides functionality for array fusion and computation using lazy
 evaluation.
@@ -59,6 +49,16 @@ Performance:
 - The optimizer can be set using the `ctx` argument in `compute`, or via `set_scheduler`
   or `with_scheduler`.
 """
+
+from ..finch_logic import (
+    Alias,
+    FinchLogicInterpreter,
+    Plan,
+    Produces,
+    Query,
+)
+from ..symbolic import gensym
+from .lazy import defer
 
 
 def get_default_scheduler():

--- a/src/finch/interface/lazy.py
+++ b/src/finch/interface/lazy.py
@@ -221,9 +221,12 @@ def expand_dims(
     if isinstance(axis, int):
         axis = (axis,)
     axis = normalize_axis_tuple(axis, x.ndim + len(axis))
-    assert not isinstance(axis, int)
-    assert len(axis) == len(set(axis)), "axis must be unique"
-    assert set(axis).issubset(range(x.ndim + len(axis))), "Invalid axis"
+    if isinstance(axis, int):
+        raise ValueError("axis must be a tuple")
+    if len(axis) != len(set(axis)):
+        raise ValueError("axis must be unique")
+    if not set(axis).issubset(range(x.ndim + len(axis))):
+        raise ValueError("Invalid axis")
     offset = [0] * (x.ndim + len(axis))
     for d in axis:
         offset[d] = 1
@@ -270,10 +273,14 @@ def squeeze(
     if isinstance(axis, int):
         axis = (axis,)
     axis = normalize_axis_tuple(axis, x.ndim)
-    assert not isinstance(axis, int)
-    assert len(axis) == len(set(axis)), "axis must be unique"
-    assert set(axis).issubset(range(x.ndim)), "Invalid axis"
-    assert all(x.shape[d] == 1 for d in axis), "axis to drop must have size 1"
+    if isinstance(axis, int):
+        raise ValueError("axis must be a tuple")
+    if len(axis) != len(set(axis)):
+        raise ValueError("axis must be unique")
+    if not set(axis).issubset(range(x.ndim)):
+        raise ValueError("Invalid axis")
+    if not all(x.shape[d] == 1 for d in axis):
+        raise ValueError("axis to drop must have size 1")
     newaxis = [n for n in range(x.ndim) if n not in axis]
     idxs_1 = tuple(Field(gensym("i")) for _ in range(x.ndim))
     idxs_2 = tuple(idxs_1[n] for n in newaxis)
@@ -335,7 +342,9 @@ def reduce(
     if axis is None:
         axis = tuple(range(x.ndim))
     axis = normalize_axis_tuple(axis, x.ndim)
-    assert axis is not None and not isinstance(axis, int)
+    if axis is None or isinstance(axis, int):
+        raise ValueError("axis must be a tuple")
+
     shape = tuple(x.shape[n] for n in range(x.ndim) if n not in axis)
     fields = tuple(Field(gensym("i")) for _ in range(x.ndim))
     data: LogicNode = Aggregate(

--- a/src/finch/interface/lazy.py
+++ b/src/finch/interface/lazy.py
@@ -1,13 +1,14 @@
 import builtins
 import operator
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from itertools import accumulate
+from itertools import accumulate, zip_longest
 from typing import Any
 
 from numpy.core.numeric import normalize_axis_tuple
 
+from ..algebra import conjugate as conj
 from ..algebra import (
     element_type,
     fill_value,
@@ -133,6 +134,12 @@ class LazyTensor(OverrideTensor):
     def __rpow__(self, other):
         return pow(defer(other), self)
 
+    def __matmul__(self, other):
+        return matmul(self, defer(other))
+
+    def __rmatmul__(self, other):
+        return matmul(defer(other), self)
+
 
 def defer(arr) -> LazyTensor:
     """
@@ -222,11 +229,16 @@ def expand_dims(
         axis = (axis,)
     axis = normalize_axis_tuple(axis, x.ndim + len(axis))
     if isinstance(axis, int):
-        raise ValueError("axis must be a tuple")
-    if len(axis) != len(set(axis)):
-        raise ValueError("axis must be unique")
+        raise IndexError(
+            f"Invalid axis: {axis}. Axis must be an integer or a tuple of integers."
+        )
+    if not len(axis) == len(set(axis)):
+        raise IndexError("axis must be unique")
     if not set(axis).issubset(range(x.ndim + len(axis))):
-        raise ValueError("Invalid axis")
+        raise IndexError(
+            f"Invalid axis: {axis}. Axis must be unique and must be in the range "
+            f"[-{x.ndim + len(axis) - 1}, {x.ndim + len(axis) - 1}]."
+        )
     offset = [0] * (x.ndim + len(axis))
     for d in axis:
         offset[d] = 1
@@ -274,13 +286,13 @@ def squeeze(
         axis = (axis,)
     axis = normalize_axis_tuple(axis, x.ndim)
     if isinstance(axis, int):
-        raise ValueError("axis must be a tuple")
+        raise ValueError(f"Invalid axis: {axis}. Axis must be a tuple of integers.")
     if len(axis) != len(set(axis)):
-        raise ValueError("axis must be unique")
+        raise ValueError(f"Invalid axis: {axis}. Axis must be unique.")
     if not set(axis).issubset(range(x.ndim)):
-        raise ValueError("Invalid axis")
-    if not all(x.shape[d] == 1 for d in axis):
-        raise ValueError("axis to drop must have size 1")
+        raise ValueError(f"Invalid axis: {axis}. Axis must be within bounds.")
+    if not builtins.all(x.shape[d] == 1 for d in axis):
+        raise ValueError(f"Invalid axis: {axis}. Axis to drop must have size 1.")
     newaxis = [n for n in range(x.ndim) if n not in axis]
     idxs_1 = tuple(Field(gensym("i")) for _ in range(x.ndim))
     idxs_2 = tuple(idxs_1[n] for n in newaxis)
@@ -538,6 +550,88 @@ def negative(x) -> LazyTensor:
     return elementwise(operator.neg, defer(x))
 
 
+def is_broadcastable(shape_a, shape_b):
+    """
+    Returns True if shape_a and shape_b are broadcastable according to numpy rules.
+    """
+    for a, b in zip_longest(reversed(shape_a), reversed(shape_b), fillvalue=1):
+        if a != b and a != 1 and b != 1:
+            return False
+    return True
+
+
+def matmul(x1, x2) -> LazyTensor:
+    """
+    Performs matrix multiplication between two tensors.
+    """
+
+    def _matmul_helper(a, b) -> LazyTensor:
+        """
+        For arrays greater than 1D
+        """
+        if a.ndim < 2 or b.ndim < 2:
+            raise ValueError("Both inputs must be at least 2D arrays")
+        if a.shape[-1] != b.shape[-2]:
+            raise ValueError("Dimensions mismatch for matrix multiplication")
+        # check all preceeding dimensions match
+        batch_a, batch_b = a.shape[:-2], b.shape[:-2]
+        if not is_broadcastable(batch_a, batch_b):
+            raise ValueError(
+                "Batch dimensions are not broadcastable for matrix multiplication"
+            )
+        return reduce(
+            operator.add,
+            multiply(expand_dims(a, axis=-1), expand_dims(b, axis=-3)),
+            axis=-2,
+        )
+
+    x1 = defer(x1)
+    x2 = defer(x2)
+
+    if x1.ndim < 1 or x2.ndim < 1:
+        raise ValueError("Both inputs must be at least 1D arrays")
+
+    if x1.ndim == 1 and x2.ndim == 1:
+        return reduce(operator.add, multiply(x1, x2), axis=0)
+
+    if x1.ndim == 1:
+        x1 = expand_dims(x1, axis=0)  # make it a row vector
+        result = _matmul_helper(x1, x2)
+        return squeeze(result, axis=-2)  # remove the prepended singleton dimension
+
+    if x2.ndim == 1:
+        x2 = expand_dims(x2, axis=1)  # make it a column vector
+        result = _matmul_helper(x1, x2)
+        return squeeze(result, axis=-1)  # remove the appended singleton dimension
+
+    return _matmul_helper(x1, x2)
+
+
+def matrix_transpose(x) -> LazyTensor:
+    """
+    Transposes the input tensor `x`.
+
+    Parameters
+    ----------
+    x: LazyTensor
+        The input tensor to be transposed. Must have at least 2 dimensions.
+
+    Returns
+    -------
+    LazyTensor
+        A new LazyTensor with the axes of `x` transposed.
+    """
+    x = defer(x)
+    if x.ndim < 2:
+        # this is following numpy's behavior.
+        # data-apis specification assumes that input is atleast 2D
+        raise ValueError(
+            "Input tensor must have at least 2 dimensions for transposition"
+        )
+    # swap the last two axes
+    return permute_dims(x, axis=(*range(x.ndim - 2), x.ndim - 1, x.ndim - 2))
+
+
 def bitwise_and(x1, x2) -> LazyTensor:
     return elementwise(operator.and_, defer(x1), defer(x2))
 
@@ -572,3 +666,107 @@ def mod(x1, x2) -> LazyTensor:
 
 def pow(x1, x2) -> LazyTensor:
     return elementwise(operator.pow, defer(x1), defer(x2))
+
+
+def conjugate(x) -> LazyTensor:
+    """
+    Computes the complex conjugate of the input tensor `x`.
+
+    Parameters
+    ----------
+    x: LazyTensor
+        The input tensor to compute the complex conjugate of.
+
+    Returns
+    -------
+    LazyTensor
+        A new LazyTensor with the complex conjugate of `x`.
+    """
+    return elementwise(conj, defer(x))
+
+
+def tensordot(
+    x1, x2, /, *, axes: int | tuple[Sequence[int], Sequence[int]]
+) -> LazyTensor:
+    """
+    Computes the tensordot operation.
+
+    Returns a LazyTensor if either x1 or x2 is a LazyTensor.
+    Otherwise, computes the result eagerly.
+    """
+    x1 = defer(x1)
+    x2 = defer(x2)
+
+    # Parse axes
+    if not isinstance(axes, tuple):
+        N = int(axes)
+        if N < 0:
+            raise ValueError("axes must be non-negative")
+        axes_a = list(range(x1.ndim - N, x1.ndim))
+        axes_b = list(range(N))
+    else:
+        axes_a, axes_b = (list(ax) for ax in axes)
+        axes_a = [axes_a] if isinstance(axes_a, int) else list(axes_a)
+        axes_b = [axes_b] if isinstance(axes_b, int) else list(axes_b)
+
+    # Normalize negative axes
+    axes_a = [(a if a >= 0 else x1.ndim + a) for a in axes_a]
+    axes_b = [(b if b >= 0 else x2.ndim + b) for b in axes_b]
+
+    # Check axes lengths and shapes
+    if len(axes_a) != len(axes_b):
+        raise ValueError("shape-mismatch for sum")
+    for a, b in zip(axes_a, axes_b, strict=True):
+        if x1.shape[a] != x2.shape[b]:
+            raise ValueError("shape-mismatch for sum")
+
+    # Move axes to contract to the end of x1 and to the front of x2
+    notin_a = [k for k in range(x1.ndim) if k not in axes_a]
+    notin_b = [k for k in range(x2.ndim) if k not in axes_b]
+    newaxes_a = notin_a + axes_a
+    newaxes_b = axes_b + notin_b
+
+    # Permute
+    x1p = permute_dims(x1, tuple(newaxes_a))
+    x2p = permute_dims(x2, tuple(newaxes_b))
+
+    # Expand x1p and x2p so that their contracted axes align for broadcasting
+    # so we can multiply them
+
+    # For x1p, add len(notin_b) singleton dims at the end
+    added_dims = tuple(-(i + 1) for i in range(len(notin_b)))
+    x1p = expand_dims(x1p, axis=added_dims)
+
+    # For x2p, add len(notin_a) singleton dims at the front
+    added_dims = tuple(i for i in range(len(notin_a)))
+    x2p = expand_dims(x2p, axis=added_dims)
+
+    # Multiply (broadcasted)
+    expanded_product = multiply(x1p, x2p)
+
+    sum_axes = tuple(range(len(notin_a), len(notin_a) + len(axes_a)))
+    return sum(expanded_product, axis=sum_axes)
+
+
+def vecdot(x1, x2, /, *, axis=-1) -> LazyTensor:
+    """
+    Computes the vector dot product along the specified axis.
+    """
+    x1 = defer(x1)
+    x2 = defer(x2)
+
+    # check broadcastability
+    if not is_broadcastable(x1.shape, x2.shape):
+        raise ValueError("Shapes are not broadcastable for vector dot product")
+
+    # check if dims of axis are the same
+    if x1.shape[axis] != x2.shape[axis]:
+        raise ValueError(
+            "Shapes are not compatible for vector dot product along the specified axis"
+        )
+
+    return reduce(
+        operator.add,
+        multiply(conjugate(x1), x2),
+        axis=axis,
+    )

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -3,9 +3,26 @@ import operator
 import pytest
 
 import numpy as np
-from numpy.testing import assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 import finch
+
+
+# Utility function to generate random complex numpy tensors
+def random_complex_array(shape):
+    """Generates a random complex array. Uses integers for both real
+    and imaginary parts to avoid floating-point issues in tests.
+
+    Args:
+        shape: A tuple specifying the shape of the array.
+
+    Returns:
+        A NumPy array of complex numbers with the given shape.
+    """
+    rng = np.random.default_rng()
+    real_part = rng.integers(0, 10, shape)
+    imag_part = rng.integers(0, 10, shape)
+    return real_part + 1j * imag_part
 
 
 @pytest.mark.parametrize(
@@ -218,3 +235,340 @@ def test_reduction_operations(a, a_wrap, ops, np_op, axis):
             result = finch.compute(result)
 
         assert_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        # 1D x 1D (dot product)
+        (np.array([1, 2, 3]), np.array([4, 5, 6])),
+        # 2D x 2D
+        (np.array([[1, 2], [3, 4]]), np.array([[5, 6], [7, 8]])),
+        # 2D x 1D
+        (np.array([[1, 2], [3, 4]]), np.array([5, 6])),
+        # 1D x 2D
+        (np.array([1, 2]), np.array([[3, 4], [5, 6]])),
+        # 3D x 3D (batched matmul)
+        (
+            np.arange(2 * 3 * 4).reshape(2, 3, 4),
+            np.arange(2 * 4 * 5).reshape(2, 4, 5),
+        ),
+        # Broadcasting cases
+        # 1D x 2D (broadcasting)
+        (np.array([1, 2]), np.arange(2 * 4).reshape(2, 4)),
+        # 1D x 3D (broadcasting)
+        (np.array([1, 2]), np.arange(3 * 2 * 5).reshape(3, 2, 5)),
+        #  4D x 3D (broadcasting)
+        (
+            np.arange(7 * 2 * 4 * 3).reshape(7, 2, 4, 3),
+            np.arange(2 * 3 * 4).reshape(2, 3, 4),
+        ),
+        # 3D x 1D (broadcasting)
+        (np.arange(3 * 2 * 4).reshape(3, 2, 4), np.arange(4)),
+        # (1, 3, 2) x (5, 2, 3)
+        (np.arange(1 * 3 * 2).reshape(1, 3, 2), np.arange(5 * 2 * 3).reshape(5, 2, 3)),
+        # Complex numbers, 4D x 5D
+        (
+            random_complex_array((2, 3, 4, 5)),
+            random_complex_array((3, 5, 6)),
+        ),
+        # mismatch dimensions
+        (
+            np.arange(7 * 2 * 3 * 4).reshape(7, 2, 3, 4),
+            np.arange(2 * 3 * 4).reshape(2, 3, 4),
+        ),
+        (np.arange(5), np.arange(4)),
+    ],
+)
+@pytest.mark.parametrize(
+    "a_wrap",
+    [
+        lambda x: x,
+        TestEagerTensor,
+        finch.defer,
+    ],
+)
+@pytest.mark.parametrize(
+    "b_wrap",
+    [
+        lambda x: x,
+        TestEagerTensor,
+        finch.defer,
+    ],
+)
+def test_matmul(a, b, a_wrap, b_wrap):
+    """
+    Tests for matrix multiplication using finch's matmul function.
+    """
+    wa = a_wrap(a)
+    wb = b_wrap(b)
+
+    try:
+        expected = np.linalg.matmul(a, b)
+    except ValueError:
+        with pytest.raises(ValueError):
+            finch.matmul(wa, wb)  # make sure matmul raises error too
+        return
+
+    result = finch.matmul(wa, wb)
+
+    if isinstance(wa, finch.LazyTensor) or isinstance(wb, finch.LazyTensor):
+        assert isinstance(result, finch.LazyTensor)
+        result = finch.compute(result)
+
+    assert_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "a",
+    [
+        np.arange(6).reshape(2, 3),
+        np.arange(12).reshape(1, 12),
+        np.arange(24).reshape(2, 3, 4),  # 3D array
+        # Complex
+        random_complex_array((5, 1, 4)),
+    ],
+)
+@pytest.mark.parametrize(
+    "a_wrap",
+    [
+        lambda x: x,
+        TestEagerTensor,
+        finch.defer,
+    ],
+)
+def test_matrix_transpose(a, a_wrap):
+    """
+    Tests for matrix transpose
+    """
+    a = np.array(a)
+    wa = a_wrap(a)
+    expected = np.linalg.matrix_transpose(a)
+
+    result = finch.matrix_transpose(wa)
+    if isinstance(result, finch.LazyTensor):
+        result = finch.compute(result)
+    assert_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "a, b, axes",
+    [
+        # 1D x 1D (dot product)
+        (np.array([1, 2, 3]), np.array([4, 5, 6]), 0),
+        # axes as int
+        (np.arange(6).reshape(2, 3), np.arange(12).reshape(3, 4), 1),
+        (np.arange(24).reshape(2, 3, 4), np.arange(12).reshape(4, 3), 1),
+        (np.arange(24).reshape(2, 4, 3), np.arange(24).reshape(4, 3, 2), 2),
+        # axes as tuple of sequences
+        (
+            np.arange(24).reshape(2, 3, 4),
+            np.arange(24).reshape(4, 3, 2),
+            ([1, 2], [1, 0]),
+        ),
+        (
+            np.arange(60).reshape(3, 4, 5),
+            np.arange(24).reshape(4, 3, 2),
+            ([0, 1], [1, 0]),
+        ),
+        # axes=0 (outer product)
+        (np.arange(3), np.arange(4), 0),
+        (np.arange(8 * 7 * 5).reshape(8, 7, 5), np.arange(12).reshape(3, 4, 1), 0),
+        # complex
+        (random_complex_array((2, 3)), random_complex_array((3, 4)), 1),
+        (
+            random_complex_array((3, 5, 4, 6)),
+            random_complex_array((6, 4, 5, 3)),
+            ([2, 1, 3], [1, 2, 0]),
+        ),
+        # mismatched axes (should raise)
+        (np.arange(6).reshape(2, 3), np.arange(8).reshape(2, 4), 1),
+    ],
+)
+@pytest.mark.parametrize(
+    "a_wrap",
+    [
+        lambda x: x,
+        TestEagerTensor,
+        finch.defer,
+    ],
+)
+@pytest.mark.parametrize(
+    "b_wrap",
+    [
+        lambda x: x,
+        TestEagerTensor,
+        finch.defer,
+    ],
+)
+def test_tensordot(a, b, axes, a_wrap, b_wrap):
+    """
+    Tests for tensordot operation according to the Array API specification.
+    See: https://data-apis.org/array-api/2024.12/API_specification/generated/array_api.tensordot.html
+    """
+    wa = a_wrap(a)
+    wb = b_wrap(b)
+    try:
+        expected = np.tensordot(a, b, axes=axes)
+    except ValueError:
+        # tensordot should raise a ValueError
+        with pytest.raises(ValueError):
+            finch.tensordot(wa, wb, axes=axes)
+        return
+    result = finch.tensordot(wa, wb, axes=axes)
+
+    if isinstance(wa, finch.LazyTensor) or isinstance(wb, finch.LazyTensor):
+        assert isinstance(result, finch.LazyTensor)
+        result = finch.compute(result)
+
+    assert_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "x1, x2, axis",
+    [
+        # 1D x 1D (scalar result)
+        (np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0]), -1),
+        # 2D x 2D (vector result)
+        (np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([[5.0, 6.0], [7.0, 8.0]]), -1),
+        # 3D x 3D, axis=-1
+        (
+            np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4),
+            np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4),
+            -1,
+        ),
+        # 3D x 3D, axis=-2
+        (
+            np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4),
+            np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4),
+            -2,
+        ),
+        # Broadcasting: (2, 3, 4) x (4,)
+        (
+            np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4),
+            np.arange(4, dtype=float),
+            -1,
+        ),
+        # Broadcasting: (3, 4) x (1, 4)
+        (
+            np.arange(3 * 4, dtype=float).reshape(3, 4),
+            np.arange(4, dtype=float).reshape(1, 4),
+            -1,
+        ),
+        # Complex numbers
+        (np.array([1 + 2j, 3 + 4j]), np.array([5 - 1j, 2 + 2j]), -1),
+        # axis=0
+        (
+            np.arange(2 * 3, dtype=float).reshape(2, 3),
+            np.arange(2 * 3, dtype=float).reshape(2, 3),
+            0,
+        ),
+        # Mismatched contracted axis
+        (np.ones((2, 3)), np.ones((2, 4)), -1),
+        (np.ones((5,)), np.ones((6,)), -1),
+        # Broadcasting not allowed on contracted axis
+        (np.ones((2, 3)), np.ones((1, 3)), 0),
+    ],
+)
+@pytest.mark.parametrize(
+    "x1_wrap",
+    [
+        lambda x: x,
+        TestEagerTensor,
+        finch.defer,
+    ],
+)
+@pytest.mark.parametrize(
+    "x2_wrap",
+    [
+        lambda x: x,
+        TestEagerTensor,
+        finch.defer,
+    ],
+)
+def test_vecdot(x1, x2, axis, x1_wrap, x2_wrap):
+    """
+    Tests for vector dot product operation according to the Array API specification.
+    See: https://data-apis.org/array-api/2024.12/API_specification/generated/array_api.vecdot.html
+    """
+    wx1 = x1_wrap(x1)
+    wx2 = x2_wrap(x2)
+
+    try:
+        expected = np.linalg.vecdot(x1, x2, axis=axis)
+    except ValueError:
+        with pytest.raises(ValueError):
+            finch.vecdot(wx1, wx2, axis=axis)
+        return
+
+    result = finch.vecdot(wx1, wx2, axis=axis)
+    if isinstance(wx1, finch.LazyTensor) or isinstance(wx2, finch.LazyTensor):
+        assert isinstance(result, finch.LazyTensor)
+        result = finch.compute(result)
+
+    assert isinstance(result, np.ndarray), "Result should be a NumPy array"
+    assert_allclose(result, expected)
+
+
+@pytest.mark.parametrize(
+    "x, axis, expected",
+    [
+        (np.array([[1], [2]]), 1, np.array([1, 2])),
+        (np.array([[[3]]]), (0, 1), np.array([3])),
+        (np.zeros((1, 2, 1, 3)), (0, 2), np.zeros((2, 3))),
+        (np.array([[[1, 2, 3]]]), 0, np.array([[1, 2, 3]])),
+    ],
+)
+def test_squeeze_valid(x, axis, expected):
+    """
+    Tests for squeeze operation
+    """
+    result = finch.squeeze(x, axis=axis)
+    np.testing.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "x, axis",
+    [
+        (np.array([[1, 2], [3, 4]]), 0),  # axis 0 is not singleton
+        (np.zeros((2, 1, 3)), (0, 2)),  # axis 0 and 2 not both singleton
+        (np.ones((1, 2, 1)), (1,)),  # axis 1 is not singleton
+    ],
+)
+def test_squeeze_invalid(x, axis):
+    with pytest.raises(ValueError):
+        finch.squeeze(x, axis=axis)
+
+
+@pytest.mark.parametrize(
+    "x, axis",
+    [
+        (np.array([1, 2, 3]), 0),
+        (np.array([1, 2, 3]), 1),
+        (np.array([[1, 2], [3, 4]]), 0),
+        (np.array([[1, 2], [3, 4]]), 1),
+        (np.array([[1, 2], [3, 4]]), 2),
+        (np.array([1, 2, 3]), -1),
+        (np.array([1, 2, 3]), -2),
+        (np.array([[1, 2], [3, 4]]), -1),
+        (np.array([[1, 2], [3, 4]]), -3),
+    ],
+)
+def test_expand_dims_valid(x, axis):
+    expected = np.expand_dims(x, axis=axis)
+    result = finch.expand_dims(x, axis=axis)
+    np.testing.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "x, axis",
+    [
+        (np.array([1, 2, 3]), 3),  # out of bounds
+        (np.array([1, 2, 3]), -4),  # out of bounds
+        (np.array([[1, 2], [3, 4]]), 4),
+        (np.array([[1, 2], [3, 4]]), -4),
+    ],
+)
+def test_expand_dims_invalid(x, axis):
+    with pytest.raises(IndexError):
+        finch.expand_dims(x, axis=axis)


### PR DESCRIPTION
Resolves #83 .

- Adds a ./src/ readme that serves as a primer into the code-base. The aim is to document any design principles and serve as a style guide for our code.
- Fixes some of the user-side assertions in the interface. For now, I have changed all the assertions in the interface (lazy.py)

_This has been merged with os/linalg-funcs so only merge this in after merging #69_

**For the reviewer:** We use a lot of assertions in the code and it is hard to tell which ones may end up floating up to be user-facing. The issue is that it is hard to identify, with proper messaging and Exception types, what error should be shown to the users at lower levels. One way to go about this would be to introduce an assert utility function that can be used for assertions that we would want to persist in the production builds (these will be internal, and effort must be made that they are not exposed to the user but will at-least be understandable/debuggable by the maintainers in case they do show up). python asserts can then be used for sanity-checks that can be optimized away without harm.