### PR TITLE
unify naming

### DIFF
--- a/src/finch/autoschedule/__init__.py
+++ b/src/finch/autoschedule/__init__.py
@@ -1,9 +1,8 @@
 from ..finch_logic import (
     Aggregate,
     Alias,
-    Deferred,
     Field,
-    Immediate,
+    Literal,
     MapJoin,
     Plan,
     Produces,
@@ -13,6 +12,7 @@ from ..finch_logic import (
     Reorder,
     Subquery,
     Table,
+    Value,
 )
 from ..symbolic import PostOrderDFS, PostWalk, PreWalk
 from .optimize import (
@@ -39,9 +39,9 @@ from .optimize import (
 __all__ = [
     "Aggregate",
     "Alias",
-    "Deferred",
+    "Value",
     "Field",
-    "Immediate",
+    "Literal",
     "MapJoin",
     "Plan",
     "PostOrderDFS",

--- a/src/finch/autoschedule/optimize.py
+++ b/src/finch/autoschedule/optimize.py
@@ -10,7 +10,7 @@ from ..finch_logic import (
     Aggregate,
     Alias,
     Field,
-    Immediate,
+    Literal,
     LogicExpression,
     LogicNode,
     LogicTree,
@@ -250,7 +250,7 @@ def propagate_map_queries_backward(root):
     def rule_1(ex):
         match ex:
             case MapJoin(
-                Immediate() as f,
+                Literal() as f,
                 args,
             ):
                 for idx, item in reversed(list(enumerate(args))):
@@ -259,7 +259,7 @@ def propagate_map_queries_backward(root):
                     match item:
                         case (
                             Aggregate(
-                                Immediate() as g, Immediate() as init, arg, idxs
+                                Literal() as g, Literal() as init, arg, idxs
                             ) as agg
                         ) if (
                             is_distributive(f.val, g.val)
@@ -278,9 +278,9 @@ def propagate_map_queries_backward(root):
     def rule_2(ex):
         match ex:
             case Aggregate(
-                Immediate() as op_1,
-                Immediate() as init_1,
-                Aggregate(op_2, Immediate() as init_2, arg, idxs_1),
+                Literal() as op_1,
+                Literal() as init_1,
+                Aggregate(op_2, Literal() as init_2, arg, idxs_1),
                 idxs_2,
             ) if op_1 == op_2 and is_identity(op_2.val, init_2.val):
                 return Aggregate(op_1, init_1, arg, idxs_1 + idxs_2)
@@ -448,7 +448,7 @@ def push_fields(root):
 
     def rule_5(ex):
         match ex:
-            case Relabel(Immediate() as arg):
+            case Relabel(Literal() as arg):
                 return arg
 
     root = Rewrite(

--- a/src/finch/codegen/c.py
+++ b/src/finch/codegen/c.py
@@ -533,7 +533,7 @@ class CContext(Context):
         lower the program to C code.
         """
         match prgm:
-            case asm.Immediate(value):
+            case asm.Literal(value):
                 # in the future, would be nice to be able to pass in constants that
                 # are more complex than C literals, maybe as globals.
                 return c_literal(self, value)
@@ -552,7 +552,7 @@ class CContext(Context):
                     self.exec(f"{feed}{var_t_code} {var_n} = {val_code};")
                 return None
             case asm.Call(f, args):
-                assert isinstance(f, asm.Immediate)
+                assert isinstance(f, asm.Literal)
                 return c_function_call(f.val, self, *args)
             case asm.Load(buf, idx):
                 return buf.result_format.c_load(self, buf, idx)
@@ -588,14 +588,14 @@ class CContext(Context):
                 idx = asm.Variable(
                     self.freshen(var.name + "_i"), buf.result_format.index_type()
                 )
-                start = asm.Immediate(0)
+                start = asm.Literal(0)
                 stop = asm.Call(
-                    asm.Immediate(operator.sub), (asm.Length(buf), asm.Immediate(1))
+                    asm.Literal(operator.sub), (asm.Length(buf), asm.Literal(1))
                 )
                 body_2 = asm.Block((asm.Assign(var, asm.Load(buf, idx)), body))
                 return self(asm.ForLoop(idx, start, stop, body_2))
             case asm.WhileLoop(cond, body):
-                if not isinstance(cond, asm.Immediate | asm.Variable):
+                if not isinstance(cond, asm.Literal | asm.Variable):
                     cond_var = asm.Variable(self.freshen("cond"), cond.result_format)
                     new_prgm = asm.Block(
                         (

--- a/src/finch/codegen/numba_backend.py
+++ b/src/finch/codegen/numba_backend.py
@@ -180,7 +180,7 @@ class NumbaContext(Context):
     def __call__(self, prgm: asm.AssemblyNode):
         feed = self.feed
         match prgm:
-            case asm.Immediate(value):
+            case asm.Literal(value):
                 return str(value)
             case asm.Variable(name, _):
                 return name
@@ -195,7 +195,7 @@ class NumbaContext(Context):
                     self.bindings[var_n] = var_t
                     self.exec(f"{feed}{var_n}: {self.full_name(var_t)} = {val_code}")
                 return None
-            case asm.Call(asm.Immediate(val), args):
+            case asm.Call(asm.Literal(val), args):
                 return f"{self.full_name(val)}({', '.join(self(arg) for arg in args)})"
             case asm.Load(buffer, idx):
                 return buffer.result_format.numba_load(self, buffer, idx)

--- a/src/finch/finch_assembly/__init__.py
+++ b/src/finch/finch_assembly/__init__.py
@@ -11,8 +11,8 @@ from .nodes import (
     Function,
     If,
     IfElse,
-    Immediate,
     Length,
+    Literal,
     Load,
     Module,
     Resize,
@@ -24,7 +24,7 @@ from .nodes import (
 
 __all__ = [
     "AssemblyNode",
-    "Immediate",
+    "Literal",
     "Variable",
     "Load",
     "Store",

--- a/src/finch/finch_assembly/interpreter.py
+++ b/src/finch/finch_assembly/interpreter.py
@@ -18,7 +18,7 @@ class AssemblyInterpreterKernel:
         self.func = asm.Variable(func_n, ret_t)
 
     def __call__(self, *args):
-        args_i = (asm.Immediate(arg) for arg in args)
+        args_i = (asm.Literal(arg) for arg in args)
         return self.ctx(asm.Call(self.func, args_i))
 
 
@@ -105,7 +105,7 @@ class AssemblyInterpreter:
         Run the program.
         """
         match prgm:
-            case asm.Immediate(value):
+            case asm.Literal(value):
                 return value
             case asm.Variable(var_n, var_t):
                 if var_n in self.types:
@@ -172,7 +172,7 @@ class AssemblyInterpreter:
                     if ctx_2.should_halt():
                         break
                     ctx_3 = self.scope()
-                    ctx_3(asm.Block((asm.Assign(var, asm.Immediate(var_e)), body)))
+                    ctx_3(asm.Block((asm.Assign(var, asm.Literal(var_e)), body)))
                     var_e = type(var_e)(var_e + 1)  # type: ignore[call-arg,operator]
                 return None
             case asm.BufferLoop(buf, var, body):
@@ -184,7 +184,7 @@ class AssemblyInterpreter:
                     ctx_3 = ctx_2.scope()
                     ctx_3(
                         asm.Block(
-                            (asm.Assign(var, asm.Load(buf, asm.Immediate(i))), body)
+                            (asm.Assign(var, asm.Load(buf, asm.Literal(i))), body)
                         )
                     )
                 return None

--- a/src/finch/finch_assembly/nodes.py
+++ b/src/finch/finch_assembly/nodes.py
@@ -51,7 +51,7 @@ class AssemblyExpression(AssemblyNode):
 
 
 @dataclass(eq=True, frozen=True)
-class Immediate(AssemblyExpression):
+class Literal(AssemblyExpression):
     """
     Represents the literal value `val`.
 
@@ -117,7 +117,7 @@ class Call(AssemblyExpression, AssemblyTree):
         args: The arguments to call on the function.
     """
 
-    op: Immediate
+    op: Literal
     args: tuple[AssemblyNode, ...]
 
     @property

--- a/src/finch/finch_logic/__init__.py
+++ b/src/finch/finch_logic/__init__.py
@@ -2,9 +2,8 @@ from .interpreter import FinchLogicInterpreter
 from .nodes import (
     Aggregate,
     Alias,
-    Deferred,
     Field,
-    Immediate,
+    Literal,
     LogicExpression,
     LogicNode,
     LogicTree,
@@ -17,6 +16,7 @@ from .nodes import (
     Reorder,
     Subquery,
     Table,
+    Value,
 )
 
 __all__ = [
@@ -24,11 +24,11 @@ __all__ = [
     "LogicExpression",
     "LogicNode",
     "LogicTree",
-    "Deferred",
+    "Value",
     "Aggregate",
     "Alias",
     "Field",
-    "Immediate",
+    "Literal",
     "MapJoin",
     "Plan",
     "Produces",

--- a/src/finch/finch_logic/interpreter.py
+++ b/src/finch/finch_logic/interpreter.py
@@ -9,9 +9,8 @@ from ..algebra import element_type, fill_value, fixpoint_type, return_type
 from .nodes import (
     Aggregate,
     Alias,
-    Deferred,
     Field,
-    Immediate,
+    Literal,
     MapJoin,
     Plan,
     Produces,
@@ -20,6 +19,7 @@ from .nodes import (
     Reorder,
     Subquery,
     Table,
+    Value,
 )
 
 
@@ -45,9 +45,9 @@ class FinchLogicInterpreter:
             print(f"Evaluating: {node}")
         # Placeholder for actual logic
         match node:
-            case Immediate(val):
+            case Literal(val):
                 return val
-            case Deferred(_):
+            case Value(_):
                 raise ValueError(
                     "The interpreter cannot evaluate a deferred node, a compiler might "
                     "generate code for it"
@@ -59,9 +59,9 @@ class FinchLogicInterpreter:
                 if alias is None:
                     raise ValueError(f"undefined tensor alias {node}")
                 return alias
-            case Table(Immediate(val), idxs):
+            case Table(Literal(val), idxs):
                 return TableValue(val, idxs)
-            case MapJoin(Immediate(op), args):
+            case MapJoin(Literal(op), args):
                 args = tuple(self(a) for a in args)
                 dims = {}
                 idxs = []
@@ -85,7 +85,7 @@ class FinchLogicInterpreter:
                     ]
                     result[*crds] = op(*vals)
                 return TableValue(result, idxs)
-            case Aggregate(Immediate(op), Immediate(init), arg, idxs):
+            case Aggregate(Literal(op), Literal(init), arg, idxs):
                 arg = self(arg)
                 dtype = fixpoint_type(op, init, element_type(arg.tns))
                 new_shape = tuple(

--- a/src/finch/finch_logic/nodes.py
+++ b/src/finch/finch_logic/nodes.py
@@ -52,7 +52,7 @@ class LogicExpression(LogicNode):
 
 
 @dataclass(eq=True, frozen=True)
-class Immediate(LogicNode):
+class Literal(LogicNode):
     """
     Represents a logical AST expression for the literal value `val`.
 
@@ -67,14 +67,14 @@ class Immediate(LogicNode):
         return id(val) if isinstance(val, np.ndarray) else hash(val)
 
     def __eq__(self, other):
-        if not isinstance(other, Immediate):
+        if not isinstance(other, Literal):
             return False
         res = self.val == other.val
         return res.all() if isinstance(res, np.ndarray) else res
 
 
 @dataclass(eq=True, frozen=True)
-class Deferred(LogicNode):
+class Value(LogicNode):
     """
     Represents a logical AST expression for an expression `ex` of type `type`,
     yet to be evaluated.
@@ -126,7 +126,7 @@ class Table(LogicTree, LogicExpression):
         idxs: The fields indexing the tensor.
     """
 
-    tns: Immediate | Deferred
+    tns: Literal | Value
     idxs: tuple[Field, ...]
 
     @property

--- a/src/finch/interface/lazy.py
+++ b/src/finch/interface/lazy.py
@@ -23,7 +23,7 @@ from ..finch_logic import (
     Aggregate,
     Alias,
     Field,
-    Immediate,
+    Literal,
     LogicNode,
     MapJoin,
     Relabel,
@@ -240,7 +240,7 @@ def defer(arr) -> LazyTensor:
     name = Alias(gensym("A"))
     idxs = tuple(Field(gensym("i")) for _ in range(arr.ndim))
     shape = tuple(arr.shape)
-    tns = Subquery(name, Table(Immediate(arr), idxs))
+    tns = Subquery(name, Table(Literal(arr), idxs))
     return LazyTensor(tns, shape, fill_value(arr), element_type(arr))
 
 
@@ -441,8 +441,8 @@ def reduce(
     shape = tuple(x.shape[n] for n in range(x.ndim) if n not in axis)
     fields = tuple(Field(gensym("i")) for _ in range(x.ndim))
     data: LogicNode = Aggregate(
-        Immediate(op),
-        Immediate(init),
+        Literal(op),
+        Literal(init),
         Relabel(x.data, fields),
         tuple(fields[i] for i in axis),
     )
@@ -505,7 +505,7 @@ def elementwise(f: Callable, *args) -> LazyTensor:
                     raise ValueError("Invalid shape for broadcasting")
                 idims.append(Field(gensym("j")))
         bargs.append(Reorder(Relabel(arg.data, tuple(idims)), tuple(odims)))
-    data = Reorder(MapJoin(Immediate(f), tuple(bargs)), idxs)
+    data = Reorder(MapJoin(Literal(f), tuple(bargs)), idxs)
     new_fill_value = f(*[x.fill_value for x in args])
     new_element_type = return_type(f, *[x.element_type for x in args])
     return LazyTensor(identify(data), shape, new_fill_value, new_element_type)

--- a/tests/test_assembly_interpreter.py
+++ b/tests/test_assembly_interpreter.py
@@ -39,21 +39,21 @@ def test_dot_product(a, b):
                     ),
                     asm.Block(
                         (
-                            asm.Assign(c, asm.Immediate(np.float64(0.0))),
+                            asm.Assign(c, asm.Literal(np.float64(0.0))),
                             asm.ForLoop(
                                 i,
-                                asm.Immediate(np.int64(0)),
+                                asm.Literal(np.int64(0)),
                                 asm.Length(ab_v),
                                 asm.Block(
                                     (
                                         asm.Assign(
                                             c,
                                             asm.Call(
-                                                asm.Immediate(operator.add),
+                                                asm.Literal(operator.add),
                                                 (
                                                     c,
                                                     asm.Call(
-                                                        asm.Immediate(operator.mul),
+                                                        asm.Literal(operator.mul),
                                                         (
                                                             asm.Load(ab_v, i),
                                                             asm.Load(bb_v, i),
@@ -88,19 +88,19 @@ def test_if_statement():
                     (),
                     asm.Block(
                         (
-                            asm.Assign(var, asm.Immediate(np.int64(5))),
+                            asm.Assign(var, asm.Literal(np.int64(5))),
                             asm.If(
                                 asm.Call(
-                                    asm.Immediate(operator.eq),
-                                    (var, asm.Immediate(np.int64(5))),
+                                    asm.Literal(operator.eq),
+                                    (var, asm.Literal(np.int64(5))),
                                 ),
                                 asm.Block(
                                     (
                                         asm.Assign(
                                             var,
                                             asm.Call(
-                                                asm.Immediate(operator.add),
-                                                (var, asm.Immediate(np.int64(10))),
+                                                asm.Literal(operator.add),
+                                                (var, asm.Literal(np.int64(10))),
                                             ),
                                         ),
                                     )
@@ -108,16 +108,16 @@ def test_if_statement():
                             ),
                             asm.IfElse(
                                 asm.Call(
-                                    asm.Immediate(operator.lt),
-                                    (var, asm.Immediate(np.int64(15))),
+                                    asm.Literal(operator.lt),
+                                    (var, asm.Literal(np.int64(15))),
                                 ),
                                 asm.Block(
                                     (
                                         asm.Assign(
                                             var,
                                             asm.Call(
-                                                asm.Immediate(operator.sub),
-                                                (var, asm.Immediate(np.int64(3))),
+                                                asm.Literal(operator.sub),
+                                                (var, asm.Literal(np.int64(3))),
                                             ),
                                         ),
                                     )
@@ -127,8 +127,8 @@ def test_if_statement():
                                         asm.Assign(
                                             var,
                                             asm.Call(
-                                                asm.Immediate(operator.mul),
-                                                (var, asm.Immediate(np.int64(2))),
+                                                asm.Literal(operator.mul),
+                                                (var, asm.Literal(np.int64(2))),
                                             ),
                                         ),
                                     )

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -95,26 +95,26 @@ def test_codegen(compiler, buffer):
                         asm.Resize(
                             a_var,
                             asm.Call(
-                                asm.Immediate(operator.mul),
-                                (asm.Length(a_var), asm.Immediate(2)),
+                                asm.Literal(operator.mul),
+                                (asm.Length(a_var), asm.Literal(2)),
                             ),
                         ),
                         asm.ForLoop(
                             i_var,
-                            asm.Immediate(0),
+                            asm.Literal(0),
                             length_var,
                             asm.Store(
                                 a_var,
                                 asm.Call(
-                                    asm.Immediate(operator.add), (i_var, length_var)
+                                    asm.Literal(operator.add), (i_var, length_var)
                                 ),
                                 asm.Call(
-                                    asm.Immediate(operator.add),
-                                    (asm.Load(a_var, i_var), asm.Immediate(1)),
+                                    asm.Literal(operator.add),
+                                    (asm.Load(a_var, i_var), asm.Literal(1)),
                                 ),
                             ),
                         ),
-                        asm.Return(asm.Immediate(0)),
+                        asm.Return(asm.Literal(0)),
                     )
                 ),
             ),
@@ -159,21 +159,21 @@ def test_dot_product(compiler, buffer):
                 ),
                 asm.Block(
                     (
-                        asm.Assign(c, asm.Immediate(np.float64(0.0))),
+                        asm.Assign(c, asm.Literal(np.float64(0.0))),
                         asm.ForLoop(
                             i,
-                            asm.Immediate(np.int64(0)),
+                            asm.Literal(np.int64(0)),
                             asm.Length(ab_v),
                             asm.Block(
                                 (
                                     asm.Assign(
                                         c,
                                         asm.Call(
-                                            asm.Immediate(operator.add),
+                                            asm.Literal(operator.add),
                                             (
                                                 c,
                                                 asm.Call(
-                                                    asm.Immediate(operator.mul),
+                                                    asm.Literal(operator.mul),
                                                     (
                                                         asm.Load(ab_v, i),
                                                         asm.Load(bb_v, i),
@@ -220,19 +220,19 @@ def test_if_statement(compiler, buffer):
                 (),
                 asm.Block(
                     (
-                        asm.Assign(var, asm.Immediate(np.int64(5))),
+                        asm.Assign(var, asm.Literal(np.int64(5))),
                         asm.If(
                             asm.Call(
-                                asm.Immediate(operator.eq),
-                                (var, asm.Immediate(np.int64(5))),
+                                asm.Literal(operator.eq),
+                                (var, asm.Literal(np.int64(5))),
                             ),
                             asm.Block(
                                 (
                                     asm.Assign(
                                         var,
                                         asm.Call(
-                                            asm.Immediate(operator.add),
-                                            (var, asm.Immediate(np.int64(10))),
+                                            asm.Literal(operator.add),
+                                            (var, asm.Literal(np.int64(10))),
                                         ),
                                     ),
                                 )
@@ -240,16 +240,16 @@ def test_if_statement(compiler, buffer):
                         ),
                         asm.IfElse(
                             asm.Call(
-                                asm.Immediate(operator.lt),
-                                (var, asm.Immediate(np.int64(15))),
+                                asm.Literal(operator.lt),
+                                (var, asm.Literal(np.int64(15))),
                             ),
                             asm.Block(
                                 (
                                     asm.Assign(
                                         var,
                                         asm.Call(
-                                            asm.Immediate(operator.sub),
-                                            (var, asm.Immediate(np.int64(3))),
+                                            asm.Literal(operator.sub),
+                                            (var, asm.Literal(np.int64(3))),
                                         ),
                                     ),
                                 )
@@ -259,8 +259,8 @@ def test_if_statement(compiler, buffer):
                                     asm.Assign(
                                         var,
                                         asm.Call(
-                                            asm.Immediate(operator.mul),
-                                            (var, asm.Immediate(np.int64(2))),
+                                            asm.Literal(operator.mul),
+                                            (var, asm.Literal(np.int64(2))),
                                         ),
                                     ),
                                 )

--- a/tests/test_logic_interpreter.py
+++ b/tests/test_logic_interpreter.py
@@ -10,7 +10,7 @@ from finch.finch_logic import (
     Alias,
     Field,
     FinchLogicInterpreter,
-    Immediate,
+    Literal,
     MapJoin,
     Plan,
     Produces,
@@ -34,14 +34,12 @@ def test_matrix_multiplication(a, b):
 
     p = Plan(
         [
-            Query(Alias("A"), Table(Immediate(a), (i, k))),
-            Query(Alias("B"), Table(Immediate(b), (k, j))),
-            Query(Alias("AB"), MapJoin(Immediate(mul), (Alias("A"), Alias("B")))),
+            Query(Alias("A"), Table(Literal(a), (i, k))),
+            Query(Alias("B"), Table(Literal(b), (k, j))),
+            Query(Alias("AB"), MapJoin(Literal(mul), (Alias("A"), Alias("B")))),
             Query(
                 Alias("C"),
-                Reorder(
-                    Aggregate(Immediate(add), Immediate(0), Alias("AB"), (k,)), (i, j)
-                ),
+                Reorder(Aggregate(Literal(add), Literal(0), Alias("AB"), (k,)), (i, j)),
             ),
             Produces((Alias("C"),)),
         ]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -28,7 +28,7 @@ from finch.finch_logic import (
     Aggregate,
     Alias,
     Field,
-    Immediate,
+    Literal,
     MapJoin,
     Plan,
     Produces,
@@ -48,7 +48,7 @@ def test_propagate_map_queries():
         (
             Query(
                 Alias("A10"),
-                Aggregate(Immediate("+"), Immediate(0), Immediate("[1,2,3]"), ()),
+                Aggregate(Literal("+"), Literal(0), Literal("[1,2,3]"), ()),
             ),
             Query(Alias("A11"), Alias("A10")),
             Produces((Alias("A11"),)),
@@ -58,7 +58,7 @@ def test_propagate_map_queries():
         (
             Query(
                 Alias("A11"),
-                MapJoin(Immediate("+"), (Immediate(0), Immediate("[1,2,3]"))),
+                MapJoin(Literal("+"), (Literal(0), Literal("[1,2,3]"))),
             ),
             Produces((Alias("A11"),)),
         )
@@ -75,18 +75,18 @@ def test_lift_subqueries():
                 Alias("A10"),
                 Plan(
                     (
-                        Subquery(Alias("C10"), Immediate(0)),
+                        Subquery(Alias("C10"), Literal(0)),
                         Subquery(
                             Alias("B10"),
                             MapJoin(
-                                Immediate("+"),
+                                Literal("+"),
                                 (
-                                    Subquery(Alias("C10"), Immediate(0)),
-                                    Immediate("[1,2,3]"),
+                                    Subquery(Alias("C10"), Literal(0)),
+                                    Literal("[1,2,3]"),
                                 ),
                             ),
                         ),
-                        Subquery(Alias("B10"), Immediate(0)),
+                        Subquery(Alias("B10"), Literal(0)),
                         Produces((Alias("B10"),)),
                     )
                 ),
@@ -99,10 +99,10 @@ def test_lift_subqueries():
         (
             Plan(
                 (
-                    Query(Alias("C10"), Immediate(0)),
+                    Query(Alias("C10"), Literal(0)),
                     Query(
                         Alias("B10"),
-                        MapJoin(Immediate("+"), (Alias("C10"), Immediate("[1,2,3]"))),
+                        MapJoin(Literal("+"), (Alias("C10"), Literal("[1,2,3]"))),
                     ),
                     Query(
                         Alias("A10"),
@@ -131,10 +131,10 @@ def test_propagate_fields():
             Query(
                 Alias("A10"),
                 MapJoin(
-                    Immediate("op"),
+                    Literal("op"),
                     (
-                        Table(Immediate("tbl1"), (Field("A1"), Field("A2"))),
-                        Table(Immediate("tbl2"), (Field("A2"), Field("A3"))),
+                        Table(Literal("tbl1"), (Field("A1"), Field("A2"))),
+                        Table(Literal("tbl2"), (Field("A2"), Field("A3"))),
                     ),
                 ),
             ),
@@ -147,10 +147,10 @@ def test_propagate_fields():
             Query(
                 Alias("A10"),
                 MapJoin(
-                    Immediate("op"),
+                    Literal("op"),
                     (
-                        Table(Immediate("tbl1"), (Field("A1"), Field("A2"))),
-                        Table(Immediate("tbl2"), (Field("A2"), Field("A3"))),
+                        Table(Literal("tbl1"), (Field("A1"), Field("A2"))),
+                        Table(Literal("tbl2"), (Field("A2"), Field("A3"))),
                     ),
                 ),
             ),
@@ -166,11 +166,11 @@ def test_propagate_fields():
     "node,pass_fn",
     [
         (
-            Aggregate(Immediate(""), Immediate(""), Reorder(Immediate(""), ()), ()),
+            Aggregate(Literal(""), Literal(""), Reorder(Literal(""), ()), ()),
             isolate_aggregates,
         ),
-        (Reformat(Immediate(""), Reorder(Immediate(""), ())), isolate_reformats),
-        (Table(Immediate(""), ()), isolate_tables),
+        (Reformat(Literal(""), Reorder(Literal(""), ())), isolate_reformats),
+        (Table(Literal(""), ()), isolate_tables),
     ],
 )
 def test_isolate_passes(node, pass_fn):
@@ -216,28 +216,28 @@ def test_push_fields():
         (
             Relabel(
                 MapJoin(
-                    Immediate("+"),
+                    Literal("+"),
                     (
-                        Table(Immediate("tbl1"), (Field("A1"), Field("A2"))),
-                        Table(Immediate("tbl2"), (Field("A2"), Field("A1"))),
+                        Table(Literal("tbl1"), (Field("A1"), Field("A2"))),
+                        Table(Literal("tbl2"), (Field("A2"), Field("A1"))),
                     ),
                 ),
                 (Field("B1"), Field("B2")),
             ),
             Relabel(
                 Aggregate(
-                    Immediate("+"),
-                    Immediate(0),
-                    Table(Immediate(""), (Field("A1"), Field("A2"), Field("A3"))),
+                    Literal("+"),
+                    Literal(0),
+                    Table(Literal(""), (Field("A1"), Field("A2"), Field("A3"))),
                     (Field("A2"),),
                 ),
                 (Field("B1"), Field("B3")),
             ),
             Reorder(
                 Aggregate(
-                    Immediate("+"),
-                    Immediate(0),
-                    Table(Immediate(""), (Field("A1"), Field("A2"), Field("A3"))),
+                    Literal("+"),
+                    Literal(0),
+                    Table(Literal(""), (Field("A1"), Field("A2"), Field("A3"))),
                     (Field("A2"),),
                 ),
                 (Field("A3"), Field("A1")),
@@ -248,33 +248,33 @@ def test_push_fields():
     expected = Plan(
         (
             MapJoin(
-                op=Immediate(val="+"),
+                op=Literal(val="+"),
                 args=(
                     Table(
-                        tns=Immediate(val="tbl1"),
+                        tns=Literal(val="tbl1"),
                         idxs=(Field(name="B1"), Field(name="B2")),
                     ),
                     Table(
-                        tns=Immediate(val="tbl2"),
+                        tns=Literal(val="tbl2"),
                         idxs=(Field(name="B2"), Field(name="B1")),
                     ),
                 ),
             ),
             Aggregate(
-                op=Immediate(val="+"),
-                init=Immediate(val=0),
+                op=Literal(val="+"),
+                init=Literal(val=0),
                 arg=Table(
-                    tns=Immediate(val=""),
+                    tns=Literal(val=""),
                     idxs=(Field(name="B1"), Field(name="A2"), Field(name="B3")),
                 ),
                 idxs=(Field(name="A2"),),
             ),
             Reorder(
                 Aggregate(
-                    Immediate("+"),
-                    Immediate(0),
+                    Literal("+"),
+                    Literal(0),
                     Reorder(
-                        Table(Immediate(""), (Field("A1"), Field("A2"), Field("A3"))),
+                        Table(Literal(""), (Field("A1"), Field("A2"), Field("A3"))),
                         (Field("A3"), Field("A2"), Field("A1")),
                     ),
                     (Field("A2"),),
@@ -293,7 +293,7 @@ def test_propagate_copy_queries():
         (
             Query(Alias("A0"), Alias("A0")),
             Query(Alias("A1"), Alias("A2")),
-            Query(Alias("A1"), Immediate(0)),
+            Query(Alias("A1"), Literal(0)),
         )
     )
 
@@ -301,7 +301,7 @@ def test_propagate_copy_queries():
         (
             Plan(),
             Plan(),
-            Query(Alias("A2"), Immediate(0)),
+            Query(Alias("A2"), Literal(0)),
         )
     )
 
@@ -315,16 +315,16 @@ def test_propagate_into_reformats():
             Query(Alias("A1"), Alias("A0")),
             Query(
                 Alias("D0"),
-                Aggregate(Immediate("*"), Immediate(1), Alias("A1"), (Field("i2"),)),
+                Aggregate(Literal("*"), Literal(1), Alias("A1"), (Field("i2"),)),
             ),
             Query(
                 Alias("B0"),
-                Aggregate(Immediate("+"), Immediate(0), Alias("A1"), (Field("i1"),)),
+                Aggregate(Literal("+"), Literal(0), Alias("A1"), (Field("i1"),)),
             ),
-            Immediate(1),
-            Query(Alias("C0"), Reformat(Immediate(3), Alias("B0"))),
-            Query(Alias("E0"), Reformat(Immediate(4), Alias("D0"))),
-            Immediate(2),
+            Literal(1),
+            Query(Alias("C0"), Reformat(Literal(3), Alias("B0"))),
+            Query(Alias("E0"), Reformat(Literal(4), Alias("D0"))),
+            Literal(2),
         )
     )
 
@@ -334,23 +334,19 @@ def test_propagate_into_reformats():
             Query(
                 Alias("E0"),
                 Reformat(
-                    Immediate(4),
-                    Aggregate(
-                        Immediate("*"), Immediate(1), Alias("A1"), (Field("i2"),)
-                    ),
+                    Literal(4),
+                    Aggregate(Literal("*"), Literal(1), Alias("A1"), (Field("i2"),)),
                 ),
             ),
             Query(
                 Alias("C0"),
                 Reformat(
-                    Immediate(3),
-                    Aggregate(
-                        Immediate("+"), Immediate(0), Alias("A1"), (Field("i1"),)
-                    ),
+                    Literal(3),
+                    Aggregate(Literal("+"), Literal(0), Alias("A1"), (Field("i1"),)),
                 ),
             ),
-            Immediate(1),
-            Immediate(2),
+            Literal(1),
+            Literal(2),
         )
     )
 
@@ -399,30 +395,30 @@ def test_lift_fields():
     plan = Plan(
         (
             Aggregate(
-                Immediate("*"),
-                Immediate(1),
-                Table(Immediate(2), (Field("i1"), Field("i2"))),
+                Literal("*"),
+                Literal(1),
+                Table(Literal(2), (Field("i1"), Field("i2"))),
                 (Field("i2"),),
             ),
             Query(
                 Alias("A0"),
                 MapJoin(
-                    Immediate("*"),
+                    Literal("*"),
                     (
-                        Table(Immediate(2), (Field("i1"), Field("i2"))),
-                        Table(Immediate(4), (Field("i1"), Field("i2"))),
+                        Table(Literal(2), (Field("i1"), Field("i2"))),
+                        Table(Literal(4), (Field("i1"), Field("i2"))),
                     ),
                 ),
             ),
             Query(
                 Alias("A0"),
                 Reformat(
-                    Immediate(0),
+                    Literal(0),
                     MapJoin(
-                        Immediate("*"),
+                        Literal("*"),
                         (
-                            Table(Immediate(2), (Field("i1"), Field("i2"))),
-                            Table(Immediate(4), (Field("i1"), Field("i2"))),
+                            Table(Literal(2), (Field("i1"), Field("i2"))),
+                            Table(Literal(4), (Field("i1"), Field("i2"))),
                         ),
                     ),
                 ),
@@ -433,10 +429,10 @@ def test_lift_fields():
     expected = Plan(
         (
             Aggregate(
-                Immediate("*"),
-                Immediate(1),
+                Literal("*"),
+                Literal(1),
                 Reorder(
-                    Table(Immediate(2), (Field("i1"), Field("i2"))),
+                    Table(Literal(2), (Field("i1"), Field("i2"))),
                     (Field("i1"), Field("i2")),
                 ),
                 (Field("i2"),),
@@ -445,10 +441,10 @@ def test_lift_fields():
                 Alias("A0"),
                 Reorder(
                     MapJoin(
-                        Immediate("*"),
+                        Literal("*"),
                         (
-                            Table(Immediate(2), (Field("i1"), Field("i2"))),
-                            Table(Immediate(4), (Field("i1"), Field("i2"))),
+                            Table(Literal(2), (Field("i1"), Field("i2"))),
+                            Table(Literal(4), (Field("i1"), Field("i2"))),
                         ),
                     ),
                     (Field("i1"), Field("i2")),
@@ -457,13 +453,13 @@ def test_lift_fields():
             Query(
                 Alias("A0"),
                 Reformat(
-                    Immediate(0),
+                    Literal(0),
                     Reorder(
                         MapJoin(
-                            Immediate("*"),
+                            Literal("*"),
                             (
-                                Table(Immediate(2), (Field("i1"), Field("i2"))),
-                                Table(Immediate(4), (Field("i1"), Field("i2"))),
+                                Table(Literal(2), (Field("i1"), Field("i2"))),
+                                Table(Literal(4), (Field("i1"), Field("i2"))),
                             ),
                         ),
                         (Field("i1"), Field("i2")),
@@ -511,7 +507,7 @@ def test_normalize_names():
 def test_concordize():
     plan = Plan(
         (
-            Query(Alias("A0"), Table(Immediate(0), (Field("i0"), Field("i1")))),
+            Query(Alias("A0"), Table(Literal(0), (Field("i0"), Field("i1")))),
             Query(
                 Alias("A1"),
                 Reorder(
@@ -532,7 +528,7 @@ def test_concordize():
 
     expected = Plan(
         (
-            Query(Alias("A0"), Table(Immediate(0), (Field("i0"), Field("i1")))),
+            Query(Alias("A0"), Table(Literal(0), (Field("i0"), Field("i1")))),
             Query(
                 Alias("A0_2"),
                 Reorder(
@@ -614,29 +610,29 @@ def test_propagate_map_queries_backward():
             Query(Alias("A0"), Alias("A1")),
             Alias("A0"),
             MapJoin(
-                Immediate(mul),
+                Literal(mul),
                 (
-                    Table(Immediate(10), (Field("i1"),)),
+                    Table(Literal(10), (Field("i1"),)),
                     Aggregate(
-                        Immediate(add),
-                        Immediate(0),
-                        Table(Immediate(10), (Field("i1"), Field("i2"), Field("i3"))),
+                        Literal(add),
+                        Literal(0),
+                        Table(Literal(10), (Field("i1"), Field("i2"), Field("i3"))),
                         (Field("i2"),),
                     ),
-                    Table(Immediate(10), (Field("i3"),)),
+                    Table(Literal(10), (Field("i3"),)),
                 ),
             ),
             Aggregate(
-                Immediate(add),
-                Immediate(10),
-                Aggregate(Immediate(add), Immediate(0), Alias("A2"), (Field("i4"),)),
+                Literal(add),
+                Literal(10),
+                Aggregate(Literal(add), Literal(0), Alias("A2"), (Field("i4"),)),
                 (Field("i5"),),
             ),
             Reorder(
                 Aggregate(
-                    Immediate(mul),
-                    Immediate(1),
-                    Table(Immediate(10), (Field("i7"),)),
+                    Literal(mul),
+                    Literal(1),
+                    Table(Literal(10), (Field("i7"),)),
                     (Field("i6"),),
                 ),
                 (Field("i5"),),
@@ -649,27 +645,25 @@ def test_propagate_map_queries_backward():
             Plan(bodies=()),
             Alias("A1"),
             Aggregate(
-                Immediate(add),
-                Immediate(0),
+                Literal(add),
+                Literal(0),
                 MapJoin(
-                    Immediate(mul),
+                    Literal(mul),
                     (
-                        Table(Immediate(10), (Field("i1"),)),
-                        Table(Immediate(10), (Field("i1"), Field("i2"), Field("i3"))),
-                        Table(Immediate(10), (Field("i3"),)),
+                        Table(Literal(10), (Field("i1"),)),
+                        Table(Literal(10), (Field("i1"), Field("i2"), Field("i3"))),
+                        Table(Literal(10), (Field("i3"),)),
                     ),
                 ),
                 (Field("i2"),),
             ),
             Aggregate(
-                Immediate(add), Immediate(10), Alias("A2"), (Field("i4"), Field("i5"))
+                Literal(add), Literal(10), Alias("A2"), (Field("i4"), Field("i5"))
             ),
             Aggregate(
-                Immediate(mul),
-                Immediate(1),
-                Reorder(
-                    Table(Immediate(10), (Field("i7"),)), (Field("i5"), Field("i6"))
-                ),
+                Literal(mul),
+                Literal(1),
+                Reorder(Table(Literal(10), (Field("i7"),)), (Field("i5"), Field("i6"))),
                 (Field("i6"),),
             ),
         )
@@ -691,14 +685,12 @@ def test_scheduler_e2e_matmul(a, b):
 
     plan = Plan(
         [
-            Query(Alias("A"), Table(Immediate(a), (i, k))),
-            Query(Alias("B"), Table(Immediate(b), (k, j))),
-            Query(Alias("AB"), MapJoin(Immediate(mul), (Alias("A"), Alias("B")))),
+            Query(Alias("A"), Table(Literal(a), (i, k))),
+            Query(Alias("B"), Table(Literal(b), (k, j))),
+            Query(Alias("AB"), MapJoin(Literal(mul), (Alias("A"), Alias("B")))),
             Query(
                 Alias("C"),
-                Reorder(
-                    Aggregate(Immediate(add), Immediate(0), Alias("AB"), (k,)), (i, j)
-                ),
+                Reorder(Aggregate(Literal(add), Literal(0), Alias("AB"), (k,)), (i, j)),
             ),
             Produces((Alias("C"),)),
         ]
@@ -721,37 +713,35 @@ def test_scheduler_e2e_sddmm():
 
     plan = Plan(
         (
-            Query(Alias("S"), Table(Immediate(s), (i, j))),
-            Query(Alias("A"), Table(Immediate(a), (i, k))),
-            Query(Alias("B"), Table(Immediate(b), (k, j))),
-            Query(Alias("AB"), MapJoin(Immediate(mul), (Alias("A"), Alias("B")))),
+            Query(Alias("S"), Table(Literal(s), (i, j))),
+            Query(Alias("A"), Table(Literal(a), (i, k))),
+            Query(Alias("B"), Table(Literal(b), (k, j))),
+            Query(Alias("AB"), MapJoin(Literal(mul), (Alias("A"), Alias("B")))),
             # matmul
-            Query(
-                Alias("C"), Aggregate(Immediate(add), Immediate(0), Alias("AB"), (k,))
-            ),
+            Query(Alias("C"), Aggregate(Literal(add), Literal(0), Alias("AB"), (k,))),
             # elemwise
-            Query(Alias("RES"), MapJoin(Immediate(mul), (Alias("C"), Alias("S")))),
+            Query(Alias("RES"), MapJoin(Literal(mul), (Alias("C"), Alias("S")))),
             Produces((Alias("RES"),)),
         )
     )
 
     expected_plan = Plan(
         (
-            Query(Alias(":A0"), Table(Immediate(a), (Field(":i0"), Field(":i1")))),
-            Query(Alias(":A1"), Table(Immediate(b), (Field(":i1"), Field(":i2")))),
-            Query(Alias(":A2"), Table(Immediate(s), (Field(":i0"), Field(":i2")))),
+            Query(Alias(":A0"), Table(Literal(a), (Field(":i0"), Field(":i1")))),
+            Query(Alias(":A1"), Table(Literal(b), (Field(":i1"), Field(":i2")))),
+            Query(Alias(":A2"), Table(Literal(s), (Field(":i0"), Field(":i2")))),
             Query(
                 Alias(":A3"),
                 Aggregate(
-                    Immediate(add),
-                    Immediate(0),
+                    Literal(add),
+                    Literal(0),
                     Reorder(
                         MapJoin(
-                            Immediate(mul),
+                            Literal(mul),
                             (
                                 Reorder(
                                     MapJoin(
-                                        Immediate(mul),
+                                        Literal(mul),
                                         (
                                             Reorder(
                                                 Relabel(


### PR DESCRIPTION
immediate and deferred are just literal and value, and it's better to keep them the same