### PR TITLE
Getting rid of some warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ addopts = --cov-report term-missing --cov-report html --cov-report=xml --cov-rep
 filterwarnings =
     ignore::PendingDeprecationWarning
 testpaths =
-    finch
+    src/finch
+    tests
 junit_family=xunit2
 xfail_strict=true

--- a/src/finch/interface/lazy.py
+++ b/src/finch/interface/lazy.py
@@ -7,7 +7,7 @@ from itertools import accumulate, zip_longest
 from typing import Any
 
 import numpy as np
-from numpy.core.numeric import normalize_axis_tuple
+from numpy.lib.array_utils import normalize_axis_tuple
 
 from ..algebra import conjugate as conj
 from ..algebra import (

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,8 +1,7 @@
 import operator
+import warnings
 
 import pytest
-
-import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -2,6 +2,8 @@ import operator
 
 import pytest
 
+import warnings
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
@@ -47,6 +49,9 @@ def test_matrix_multiplication(a, b):
 
 
 class TestEagerTensor(finch.EagerTensor):
+    # This class doesn't define any pytests
+    __test__ = False
+
     def __init__(self, array):
         self.array = np.array(array)
 
@@ -134,17 +139,29 @@ def test_elementwise_operations(a, b, a_wrap, b_wrap, ops, np_op):
     wa = a_wrap(a)
     wb = b_wrap(b)
 
-    expected = np_op(a, b)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message="invalid value encountered in",
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message="divide by zero encountered in",
+        )
 
-    for op in ops:
-        result = op(wa, wb)
+        expected = np_op(a, b)
 
-        if isinstance(wa, finch.LazyTensor) or isinstance(wb, finch.LazyTensor):
-            assert isinstance(result, finch.LazyTensor)
+        for op in ops:
+            result = op(wa, wb)
 
-            result = finch.compute(result)
+            if isinstance(wa, finch.LazyTensor) or isinstance(wb, finch.LazyTensor):
+                assert isinstance(result, finch.LazyTensor)
 
-        assert_equal(result, expected)
+                result = finch.compute(result)
+
+            assert_equal(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -189,17 +206,29 @@ def test_elementwise_operations(a, b, a_wrap, b_wrap, ops, np_op):
 def test_unary_operations(a, a_wrap, ops, np_op):
     wa = a_wrap(a)
 
-    expected = np_op(a)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message="invalid value encountered in",
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message="divide by zero encountered in",
+        )
 
-    for op in ops:
-        result = op(wa)
+        expected = np_op(a)
 
-        if isinstance(wa, finch.LazyTensor):
-            assert isinstance(result, finch.LazyTensor)
+        for op in ops:
+            result = op(wa)
 
-            result = finch.compute(result)
+            if isinstance(wa, finch.LazyTensor):
+                assert isinstance(result, finch.LazyTensor)
 
-        assert_equal(result, expected)
+                result = finch.compute(result)
+
+            assert_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -22,4 +22,4 @@ def test_issue_50():
     # If replaced above with below line, no error
     # n = finch.defer(np.array([[2, 2, 2, 2], [2, 2, 2, 2]]))
     o = finch.defer(np.array([[3, 3, 3, 3], [3, 3, 3, 3]]))
-    return finch.add(finch.add(finch.subtract(x, m), n), o)
+    finch.add(finch.add(finch.subtract(x, m), n), o)


### PR DESCRIPTION
Some minor changes to get rid of warnings when running the test suite. Not sure everything here is reasonable, thought I'd check with a draft PR.

The thing I'm most unsure about is suppressing runtime warnings from numpy when testing, but this feels reasonable to me. My primary uncertainty: do you want to handle these warnings and/or test the behavior of the warnings themselves?
