### PR TITLE
Use concordant merge for fields in `MapJoin` processing

### DIFF
--- a/src/finch/autoschedule/optimize.py
+++ b/src/finch/autoschedule/optimize.py
@@ -24,6 +24,7 @@ from ..finch_logic import (
     Subquery,
     Table,
 )
+from ..finch_logic._utils import NonConcordantLists, merge_concordant
 from ..symbolic import (
     Chain,
     Fixpoint,
@@ -247,7 +248,7 @@ def propagate_map_queries_backward(root):
     root = Rewrite(PreWalk(Chain([rule_1, rule_2])))(root)
     root = push_fields(root)
 
-    def rule_1(ex):
+    def rule_3(ex):
         match ex:
             case MapJoin(
                 Literal() as f,
@@ -275,7 +276,7 @@ def propagate_map_queries_backward(root):
                             )
                 return None
 
-    def rule_2(ex):
+    def rule_4(ex):
         match ex:
             case Aggregate(
                 Literal() as op_1,
@@ -285,12 +286,17 @@ def propagate_map_queries_backward(root):
             ) if op_1 == op_2 and is_identity(op_2.val, init_2.val):
                 return Aggregate(op_1, init_1, arg, idxs_1 + idxs_2)
 
-    def rule_3(ex):
+    def rule_5(ex):
         match ex:
             case Reorder(Aggregate(op, init, arg, idxs_1), idxs_2):
-                return Aggregate(op, init, Reorder(arg, idxs_2 + idxs_1), idxs_1)
+                merged_idxs: list[Field]
+                try:
+                    merged_idxs = merge_concordant([arg.fields, idxs_1, idxs_2])
+                except NonConcordantLists:
+                    merged_idxs = list(idxs_2 + idxs_1)
+                return Aggregate(op, init, Reorder(arg, tuple(merged_idxs)), idxs_1)
 
-    return Rewrite(Fixpoint(PreWalk(Chain([rule_1, rule_2, rule_3]))))(root)
+    return Rewrite(Fixpoint(PreWalk(Chain([rule_3, rule_4, rule_5]))))(root)
 
 
 def propagate_copy_queries(root):

--- a/src/finch/finch_logic/_utils.py
+++ b/src/finch/finch_logic/_utils.py
@@ -1,0 +1,27 @@
+from collections.abc import Iterable
+
+from .nodes import Field
+
+
+class NonConcordantLists(Exception):
+    pass
+
+
+def merge_concordant(args: Iterable[Iterable[Field]]) -> list[Field]:
+    merge_list: list[Field] = []
+    visited: set[Field] = set()
+
+    for arg in args:
+        idx = 0
+        for f in arg:
+            if f not in visited:
+                visited.add(f)
+                merge_list.insert(idx, f)
+                idx += 1
+            else:
+                next_idx = merge_list.index(f)
+                if next_idx < idx:
+                    raise NonConcordantLists
+                idx = next_idx + 1
+
+    return merge_list

--- a/src/finch/finch_logic/nodes.py
+++ b/src/finch/finch_logic/nodes.py
@@ -168,11 +168,13 @@ class MapJoin(LogicTree, LogicExpression):
     @property
     def fields(self) -> list[Field]:
         """Returns fields of the node."""
-        # (mtsokol) I'm not sure if this comment still applies - the order is preserved.
-        # TODO: this is wrong here: the overall order should at least be concordant with
-        # the args if the args are concordant
-        fields = [f for fs in (x.fields for x in self.args) for f in fs]
-        return list(dict.fromkeys(fields))
+        from ._utils import NonConcordantLists, merge_concordant
+
+        args_fields = [x.fields for x in self.args]
+        try:
+            return merge_concordant(args_fields)
+        except NonConcordantLists:
+            return list(dict.fromkeys([f for fs in args_fields for f in fs]))
 
     @classmethod
     def from_children(cls, op, *args):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -632,10 +632,10 @@ def test_propagate_map_queries_backward():
                 Aggregate(
                     Literal(mul),
                     Literal(1),
-                    Table(Literal(10), (Field("i7"),)),
-                    (Field("i6"),),
+                    Table(Literal(10), (Field("i6"), Field("i7"), Field("i8"))),
+                    (Field("i7"),),
                 ),
-                (Field("i5"),),
+                (Field("i6"), Field("i8")),
             ),
         )
     )
@@ -663,8 +663,18 @@ def test_propagate_map_queries_backward():
             Aggregate(
                 Literal(mul),
                 Literal(1),
-                Reorder(Table(Literal(10), (Field("i7"),)), (Field("i5"), Field("i6"))),
-                (Field("i6"),),
+                Reorder(
+                    Table(
+                        Literal(10),
+                        (
+                            Field("i6"),
+                            Field("i7"),
+                            Field("i8"),
+                        ),
+                    ),
+                    (Field("i6"), Field("i7"), Field("i8")),
+                ),
+                (Field("i7"),),
             ),
         )
     )
@@ -684,7 +694,7 @@ def test_scheduler_e2e_matmul(a, b):
     i, j, k = Field("i"), Field("j"), Field("k")
 
     plan = Plan(
-        [
+        (
             Query(Alias("A"), Table(Literal(a), (i, k))),
             Query(Alias("B"), Table(Literal(b), (k, j))),
             Query(Alias("AB"), MapJoin(Literal(mul), (Alias("A"), Alias("B")))),
@@ -693,7 +703,7 @@ def test_scheduler_e2e_matmul(a, b):
                 Reorder(Aggregate(Literal(add), Literal(0), Alias("AB"), (k,)), (i, j)),
             ),
             Produces((Alias("C"),)),
-        ]
+        )
     )
 
     plan_opt = optimize(plan)


### PR DESCRIPTION
Hi @willow-ahrens,

I'm going back with the issue I described earlier with SDDMM schedule optimization. I managed to solve it and now the final schedule matches Finch.jl counterpart and is exactly as need, regardless of `Relabel`/`Reorder` nesting.

The culprit arose from the fact that `propagate_map_queries_backward` used non-concordant merge of Fields in `Reorder(Aggregate())` rule and that `MapJoin.fields` returned non-concordant merge of Fields of underling `args` (Turs out we had a TODO for it).

To give an example: if we have a `Reorder(Agg(MapJoin((F0, F1), (F1, F2)), F1), (F0, F2))` the original transformation would do `Agg(Reorder(MapJoin((F0, F1), (F1, F2)), (F0, F2, F1)), F1)`. `(F0, F2, F1)` and `(F1, F2)` aren't concordant which prevented Reorder from being removed and caused those transpose intermediaries I reported. 

With `merge_concordant(...)` the order of the merged list is concordant, here `(F0, F1, F2)`, assuming args are concord (otherwise falls back to previous merging). WDYT?

I think this could also apply to Finch.jl.