### PR TITLE
Fix for bad query_property error - issue #102

### DIFF
--- a/src/finch/algebra/algebra.py
+++ b/src/finch/algebra/algebra.py
@@ -81,14 +81,16 @@ def query_property(obj: type | Hashable, attr: str, prop: str, *args) -> Any:
         AttributeError: If the property is not implemented for the given type.
     """
     if not isinstance(obj, type):
+        # Only catch TypeError for hashability check
         try:
             hash(obj)
+        except TypeError:
+            t = type(obj)
+        else:
             query_fn = _properties.get((obj, attr, prop))
             if query_fn is not None:
                 return query_fn(obj, *args)
-        except TypeError:
-            pass
-        t = type(obj)
+            t = type(obj)
     else:
         t = obj
 


### PR DESCRIPTION
Attempts to fix #102 
Overview: 
This pull request refines error handling in the `query_property` function within `src/finch/algebra/algebra.py`. The change ensures that `TypeError` is caught only during the hashability check, improving clarity and reducing unnecessary exception handling.

Error handling improvement:

* [`src/finch/algebra/algebra.py`](diffhunk://#diff-c16e3d6420f474c578e1330d5427fcfd763e84d817fccc1a308f5743c9bc1c39R84-L90): Updated the `query_property` function to isolate the `TypeError` exception to the hashability check, ensuring that the exception handling is more precise and does not interfere with subsequent logic.

#102 had been lingering around for a while. This fixes the bad case given in there.