### PR TITLE
Add `eval`uable reprs for IRs

### DIFF
--- a/src/finch/finch_assembly/__init__.py
+++ b/src/finch/finch_assembly/__init__.py
@@ -63,6 +63,5 @@ __all__ = [
     "Variable",
     "WhileLoop",
     "element_type",
-    "has_format",
     "length_type",
 ]

--- a/src/finch/finch_assembly/nodes.py
+++ b/src/finch/finch_assembly/nodes.py
@@ -1,9 +1,9 @@
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any
 
 from ..algebra import return_type
-from ..symbolic import LiteralRepr, Term, TermTree
+from ..symbolic import Term, TermTree, literal_repr
 from .buffer import element_type, length_type
 
 
@@ -52,7 +52,7 @@ class AssemblyExpression(AssemblyNode):
 
 
 @dataclass(eq=True, frozen=True)
-class Literal(AssemblyExpression, LiteralRepr):
+class Literal(AssemblyExpression):
     """
     Represents the literal value `val`.
 
@@ -68,11 +68,11 @@ class Literal(AssemblyExpression, LiteralRepr):
         return type(self.val)
 
     def __repr__(self) -> str:
-        return self.literal_repr()
+        return literal_repr(type(self).__name__, asdict(self))
 
 
 @dataclass(eq=True, frozen=True)
-class Variable(AssemblyExpression, LiteralRepr):
+class Variable(AssemblyExpression):
     """
     Represents a logical AST expression for a variable named `name`, which
     will hold a value of type `type`.
@@ -91,7 +91,7 @@ class Variable(AssemblyExpression, LiteralRepr):
         return self.type
 
     def __repr__(self) -> str:
-        return self.literal_repr()
+        return literal_repr(type(self).__name__, asdict(self))
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/finch/finch_assembly/nodes.py
+++ b/src/finch/finch_assembly/nodes.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..algebra import return_type
-from ..symbolic import Term, TermTree
+from ..symbolic import LiteralRepr, Term, TermTree
 from .buffer import element_type, length_type
 
 
@@ -52,7 +52,7 @@ class AssemblyExpression(AssemblyNode):
 
 
 @dataclass(eq=True, frozen=True)
-class Literal(AssemblyExpression):
+class Literal(AssemblyExpression, LiteralRepr):
     """
     Represents the literal value `val`.
 
@@ -67,9 +67,12 @@ class Literal(AssemblyExpression):
         """Returns the type of the expression."""
         return type(self.val)
 
+    def __repr__(self) -> str:
+        return self.literal_repr()
+
 
 @dataclass(eq=True, frozen=True)
-class Variable(AssemblyExpression):
+class Variable(AssemblyExpression, LiteralRepr):
     """
     Represents a logical AST expression for a variable named `name`, which
     will hold a value of type `type`.
@@ -86,6 +89,9 @@ class Variable(AssemblyExpression):
     def result_format(self):
         """Returns the type of the expression."""
         return self.type
+
+    def __repr__(self) -> str:
+        return self.literal_repr()
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/finch/finch_logic/nodes.py
+++ b/src/finch/finch_logic/nodes.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Self
 
 import numpy as np
 
-from ..symbolic import LiteralRepr, Term, TermTree
+from ..symbolic import Term, TermTree, literal_repr
 
 
 @dataclass(eq=True, frozen=True)
@@ -52,7 +52,7 @@ class LogicExpression(LogicNode):
 
 
 @dataclass(eq=True, frozen=True)
-class Literal(LogicNode, LiteralRepr):
+class Literal(LogicNode):
     """
     Represents a logical AST expression for the literal value `val`.
 
@@ -73,7 +73,7 @@ class Literal(LogicNode, LiteralRepr):
         return res.all() if isinstance(res, np.ndarray) else res
 
     def __repr__(self) -> str:
-        return self.literal_repr()
+        return literal_repr(type(self).__name__, asdict(self))
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/finch/finch_logic/nodes.py
+++ b/src/finch/finch_logic/nodes.py
@@ -6,7 +6,7 @@ from typing import Any, Self
 
 import numpy as np
 
-from ..symbolic import Term, TermTree
+from ..symbolic import LiteralRepr, Term, TermTree
 
 
 @dataclass(eq=True, frozen=True)
@@ -52,7 +52,7 @@ class LogicExpression(LogicNode):
 
 
 @dataclass(eq=True, frozen=True)
-class Literal(LogicNode):
+class Literal(LogicNode, LiteralRepr):
     """
     Represents a logical AST expression for the literal value `val`.
 
@@ -71,6 +71,9 @@ class Literal(LogicNode):
             return False
         res = self.val == other.val
         return res.all() if isinstance(res, np.ndarray) else res
+
+    def __repr__(self) -> str:
+        return self.literal_repr()
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/finch/finch_notation/nodes.py
+++ b/src/finch/finch_notation/nodes.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..algebra import element_type, query_property, return_type
-from ..symbolic import Term, TermTree
+from ..symbolic import LiteralRepr, Term, TermTree
 
 
 @dataclass(eq=True, frozen=True)
@@ -53,7 +53,7 @@ class NotationExpression(NotationNode):
 
 
 @dataclass(eq=True, frozen=True)
-class Literal(NotationExpression):
+class Literal(NotationExpression, LiteralRepr):
     """
     Notation AST expression for the literal value `val`.
     """
@@ -64,9 +64,12 @@ class Literal(NotationExpression):
     def result_format(self):
         return type(self.val)
 
+    def __repr__(self) -> str:
+        return self.literal_repr()
+
 
 @dataclass(eq=True, frozen=True)
-class Value(NotationExpression):
+class Value(NotationExpression, LiteralRepr):
     """
     Notation AST expression for host code `val` expected to evaluate to a value of
     type `type_`.
@@ -79,9 +82,12 @@ class Value(NotationExpression):
     def result_format(self):
         return self.type_
 
+    def __repr__(self) -> str:
+        return self.literal_repr()
+
 
 @dataclass(eq=True, frozen=True)
-class Variable(NotationExpression):
+class Variable(NotationExpression, LiteralRepr):
     """
     Notation AST expression for a variable named `name`.
 
@@ -96,6 +102,9 @@ class Variable(NotationExpression):
     @property
     def result_format(self):
         return self.type_
+
+    def __repr__(self) -> str:
+        return self.literal_repr()
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/finch/finch_notation/nodes.py
+++ b/src/finch/finch_notation/nodes.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any
 
 from ..algebra import element_type, query_property, return_type
-from ..symbolic import LiteralRepr, Term, TermTree
+from ..symbolic import Term, TermTree, literal_repr
 
 
 @dataclass(eq=True, frozen=True)
@@ -53,7 +53,7 @@ class NotationExpression(NotationNode):
 
 
 @dataclass(eq=True, frozen=True)
-class Literal(NotationExpression, LiteralRepr):
+class Literal(NotationExpression):
     """
     Notation AST expression for the literal value `val`.
     """
@@ -65,11 +65,11 @@ class Literal(NotationExpression, LiteralRepr):
         return type(self.val)
 
     def __repr__(self) -> str:
-        return self.literal_repr()
+        return literal_repr(type(self).__name__, asdict(self))
 
 
 @dataclass(eq=True, frozen=True)
-class Value(NotationExpression, LiteralRepr):
+class Value(NotationExpression):
     """
     Notation AST expression for host code `val` expected to evaluate to a value of
     type `type_`.
@@ -83,11 +83,11 @@ class Value(NotationExpression, LiteralRepr):
         return self.type_
 
     def __repr__(self) -> str:
-        return self.literal_repr()
+        return literal_repr(type(self).__name__, asdict(self))
 
 
 @dataclass(eq=True, frozen=True)
-class Variable(NotationExpression, LiteralRepr):
+class Variable(NotationExpression):
     """
     Notation AST expression for a variable named `name`.
 
@@ -104,7 +104,7 @@ class Variable(NotationExpression, LiteralRepr):
         return self.type_
 
     def __repr__(self) -> str:
-        return self.literal_repr()
+        return literal_repr(type(self).__name__, asdict(self))
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/finch/symbolic/__init__.py
+++ b/src/finch/symbolic/__init__.py
@@ -9,6 +9,7 @@ from .rewriters import (
     Rewrite,
 )
 from .term import (
+    LiteralRepr,
     PostOrderDFS,
     PreOrderDFS,
     Term,
@@ -21,6 +22,7 @@ __all__ = [
     "Fixpoint",
     "Format",
     "Formattable",
+    "LiteralRepr",
     "Namespace",
     "PostOrderDFS",
     "PostWalk",

--- a/src/finch/symbolic/__init__.py
+++ b/src/finch/symbolic/__init__.py
@@ -9,11 +9,11 @@ from .rewriters import (
     Rewrite,
 )
 from .term import (
-    LiteralRepr,
     PostOrderDFS,
     PreOrderDFS,
     Term,
     TermTree,
+    literal_repr,
 )
 
 __all__ = [
@@ -22,7 +22,6 @@ __all__ = [
     "Fixpoint",
     "Format",
     "Formattable",
-    "LiteralRepr",
     "Namespace",
     "PostOrderDFS",
     "PostWalk",
@@ -35,4 +34,5 @@ __all__ = [
     "format",
     "gensym",
     "has_format",
+    "literal_repr",
 ]

--- a/src/finch/symbolic/term.py
+++ b/src/finch/symbolic/term.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from inspect import isbuiltin, isclass, isfunction
 from typing import Any, Self
 
@@ -72,26 +72,16 @@ class TermTree(Term, ABC):
         ...
 
 
-@dataclass(frozen=True, eq=True)
-class LiteralRepr:
-    """
-    Helper class to have `eval`uable reprs for builtins functions.
-    """
+def _get_repr(val: Any) -> str:
+    if isbuiltin(val) or isclass(val) or isfunction(val):
+        return f"{val.__module__}.{val.__qualname__}"
+    return repr(val)
 
-    @staticmethod
-    def _get_repr(val: Any) -> str:
-        if isbuiltin(val) or isclass(val) or isfunction(val):
-            return f"{val.__module__}.{val.__qualname__}"
-        return repr(val)
 
-    def literal_repr(self) -> str:
-        fields = asdict(self)
-        return (
-            type(self).__qualname__
-            + "("
-            + ", ".join([f"{k}={self._get_repr(v)}" for k, v in fields.items()])
-            + ")"
-        )
+def literal_repr(name: str, fields: dict[str, Any]) -> str:
+    return (
+        name + "(" + ", ".join([f"{k}={_get_repr(v)}" for k, v in fields.items()]) + ")"
+    )
 
 
 def PostOrderDFS(node: Term) -> Iterator[Term]:

--- a/src/finch/symbolic/term.py
+++ b/src/finch/symbolic/term.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from inspect import isbuiltin, isclass, isfunction
 from typing import Any, Self
 
 """
@@ -69,6 +70,28 @@ class TermTree(Term, ABC):
     def children(self) -> list[Term]:
         """Return the children (AKA tail) of the S-expression."""
         ...
+
+
+@dataclass(frozen=True, eq=True)
+class LiteralRepr:
+    """
+    Helper class to have `eval`uable reprs for builtins functions.
+    """
+
+    @staticmethod
+    def _get_repr(val: Any) -> str:
+        if isbuiltin(val) or isclass(val) or isfunction(val):
+            return f"{val.__module__}.{val.__qualname__}"
+        return repr(val)
+
+    def literal_repr(self) -> str:
+        fields = asdict(self)
+        return (
+            type(self).__qualname__
+            + "("
+            + ", ".join([f"{k}={self._get_repr(v)}" for k, v in fields.items()])
+            + ")"
+        )
 
 
 def PostOrderDFS(node: Term) -> Iterator[Term]:

--- a/tests/test_assembly_interpreter.py
+++ b/tests/test_assembly_interpreter.py
@@ -1,13 +1,27 @@
+import _operator  # noqa: F401
 import operator
 from collections import namedtuple
 
 import pytest
 
+import numpy  # noqa: F401, ICN001
 import numpy as np
 
 from finch import finch_assembly as asm
 from finch.codegen import NumpyBuffer
-from finch.finch_assembly import AssemblyInterpreter
+from finch.finch_assembly import (  # noqa: F401
+    AssemblyInterpreter,
+    Assign,
+    Block,
+    Call,
+    Function,
+    If,
+    IfElse,
+    Literal,
+    Module,
+    Return,
+    Variable,
+)
 from finch.symbolic import format
 
 
@@ -89,70 +103,72 @@ def test_dot_product(a, b):
 
 def test_if_statement():
     var = asm.Variable("a", np.int64)
-    mod = AssemblyInterpreter()(
-        asm.Module(
-            (
-                asm.Function(
-                    asm.Variable("if_else", np.int64),
-                    (),
-                    asm.Block(
-                        (
-                            asm.Assign(var, asm.Literal(np.int64(5))),
-                            asm.If(
-                                asm.Call(
-                                    asm.Literal(operator.eq),
-                                    (var, asm.Literal(np.int64(5))),
-                                ),
-                                asm.Block(
-                                    (
-                                        asm.Assign(
-                                            var,
-                                            asm.Call(
-                                                asm.Literal(operator.add),
-                                                (var, asm.Literal(np.int64(10))),
-                                            ),
-                                        ),
-                                    )
-                                ),
+    root = asm.Module(
+        (
+            asm.Function(
+                asm.Variable("if_else", np.int64),
+                (),
+                asm.Block(
+                    (
+                        asm.Assign(var, asm.Literal(np.int64(5))),
+                        asm.If(
+                            asm.Call(
+                                asm.Literal(operator.eq),
+                                (var, asm.Literal(np.int64(5))),
                             ),
-                            asm.IfElse(
-                                asm.Call(
-                                    asm.Literal(operator.lt),
-                                    (var, asm.Literal(np.int64(15))),
-                                ),
-                                asm.Block(
-                                    (
-                                        asm.Assign(
-                                            var,
-                                            asm.Call(
-                                                asm.Literal(operator.sub),
-                                                (var, asm.Literal(np.int64(3))),
-                                            ),
+                            asm.Block(
+                                (
+                                    asm.Assign(
+                                        var,
+                                        asm.Call(
+                                            asm.Literal(operator.add),
+                                            (var, asm.Literal(np.int64(10))),
                                         ),
-                                    )
-                                ),
-                                asm.Block(
-                                    (
-                                        asm.Assign(
-                                            var,
-                                            asm.Call(
-                                                asm.Literal(operator.mul),
-                                                (var, asm.Literal(np.int64(2))),
-                                            ),
-                                        ),
-                                    )
-                                ),
+                                    ),
+                                )
                             ),
-                            asm.Return(var),
-                        )
-                    ),
+                        ),
+                        asm.IfElse(
+                            asm.Call(
+                                asm.Literal(operator.lt),
+                                (var, asm.Literal(np.int64(15))),
+                            ),
+                            asm.Block(
+                                (
+                                    asm.Assign(
+                                        var,
+                                        asm.Call(
+                                            asm.Literal(operator.sub),
+                                            (var, asm.Literal(np.int64(3))),
+                                        ),
+                                    ),
+                                )
+                            ),
+                            asm.Block(
+                                (
+                                    asm.Assign(
+                                        var,
+                                        asm.Call(
+                                            asm.Literal(operator.mul),
+                                            (var, asm.Literal(np.int64(2))),
+                                        ),
+                                    ),
+                                )
+                            ),
+                        ),
+                        asm.Return(var),
+                    )
                 ),
-            )
+            ),
         )
     )
 
+    mod = AssemblyInterpreter()(root)
+
     result = mod.if_else()
     assert result == 30
+
+    assert root == eval(repr(root))
 
 
 def test_simple_struct():

--- a/tests/test_logic_interpreter.py
+++ b/tests/test_logic_interpreter.py
@@ -1,8 +1,10 @@
+import _operator  # noqa: F401
 from operator import add, mul
 
 import pytest
 
 import numpy as np
+from numpy import array  # noqa: F401
 from numpy.testing import assert_equal
 
 from finch.finch_logic import (
@@ -50,3 +52,5 @@ def test_matrix_multiplication(a, b):
     expected = np.matmul(a, b)
 
     assert_equal(result, expected)
+
+    assert p == eval(repr(p))

--- a/tests/test_notation_interpreter.py
+++ b/tests/test_notation_interpreter.py
@@ -1,11 +1,32 @@
+import _operator  # noqa: F401
 import operator
 
 import pytest
 
+import numpy  # noqa: F401, ICN001
 import numpy as np
 from numpy.testing import assert_equal
 
+import finch  # noqa: F401
 import finch.finch_notation as ntn
+from finch.finch_notation import (  # noqa: F401
+    Access,
+    Assign,
+    Block,
+    Call,
+    Declare,
+    Freeze,
+    Function,
+    Increment,
+    Literal,
+    Loop,
+    Module,
+    Read,
+    Return,
+    Unwrap,
+    Update,
+    Variable,
+)
 
 
 @pytest.mark.parametrize(
@@ -124,3 +145,5 @@ def test_matrix_multiplication(a, b):
     expected = np.matmul(a, b)
 
     assert_equal(result, expected)
+
+    assert prgm == eval(repr(prgm))


### PR DESCRIPTION
Hi @willow-ahrens,

`eval`uable reprs are added in this PR for all three IRs, with round-trip tests you suggested. `LiteralRepr` is used to aid Literal, Variable, and Value nodes - I wonder if `LeafRepr` would fit here more, WDYT? 