### PR TITLE
Safe Buffer implementation

### DIFF
--- a/src/finch/finch_assembly/__init__.py
+++ b/src/finch/finch_assembly/__init__.py
@@ -27,6 +27,7 @@ from .nodes import (
     Variable,
     WhileLoop,
 )
+from .safe_buffer import SafeBuffer, SafeBufferFormat, make_safe
 from .struct import AssemblyStructFormat, NamedTupleFormat, TupleFormat
 
 __all__ = [
@@ -54,6 +55,8 @@ __all__ = [
     "Repack",
     "Resize",
     "Return",
+    "SafeBuffer",
+    "SafeBufferFormat",
     "SetAttr",
     "Slot",
     "Stack",
@@ -64,4 +67,5 @@ __all__ = [
     "WhileLoop",
     "element_type",
     "length_type",
+    "make_safe",
 ]

--- a/src/finch/finch_assembly/__init__.py
+++ b/src/finch/finch_assembly/__init__.py
@@ -27,7 +27,7 @@ from .nodes import (
     Variable,
     WhileLoop,
 )
-from .safe_buffer import SafeBuffer, SafeBufferFormat, make_safe
+from .safe_buffer import SafeBuffer, SafeBufferFType, make_safe
 from .struct import AssemblyStructFType, NamedTupleFType, TupleFType
 
 __all__ = [
@@ -56,7 +56,7 @@ __all__ = [
     "Resize",
     "Return",
     "SafeBuffer",
-    "SafeBufferFormat",
+    "SafeBufferFType",
     "SetAttr",
     "Slot",
     "Stack",

--- a/src/finch/finch_assembly/safe_buffer.py
+++ b/src/finch/finch_assembly/safe_buffer.py
@@ -1,4 +1,4 @@
-from .buffer import Buffer, BufferFormat
+from .buffer import Buffer, BufferFType
 
 
 class SafeBuffer(Buffer):
@@ -19,11 +19,11 @@ class SafeBuffer(Buffer):
         self._underlying_buffer = underlying_buffer
 
     @property
-    def format(self):
+    def ftype(self):
         """
         Returns the format of the safe buffer.
         """
-        return SafeBufferFormat(self._underlying_buffer.format)
+        return SafeBufferFType(self._underlying_buffer.ftype)
 
     def length(self):
         """
@@ -114,31 +114,31 @@ class SafeBuffer(Buffer):
         return self._underlying_buffer
 
 
-class SafeBufferFormat(BufferFormat):
+class SafeBufferFType(BufferFType):
     """
     A format for SafeBuffer that wraps another buffer format.
     """
 
-    def __init__(self, underlying_format: BufferFormat):
+    def __init__(self, underlying_format: BufferFType):
         """
         Initialize with the underlying buffer format to wrap.
 
         Args:
             underlying_format: The buffer format to add safety to
         """
-        if not isinstance(underlying_format, BufferFormat):
+        if not isinstance(underlying_format, BufferFType):
             raise TypeError(
-                f"Expected BufferFormat instance, got {type(underlying_format)}"
+                f"Expected BufferFType instance, got {type(underlying_format)}"
             )
         self._underlying_format = underlying_format
 
     def __eq__(self, other):
-        if not isinstance(other, SafeBufferFormat):
+        if not isinstance(other, SafeBufferFType):
             return False
         return self._underlying_format == other._underlying_format
 
     def __hash__(self):
-        return hash(("SafeBufferFormat", self._underlying_format))
+        return hash(("SafeBufferFType", self._underlying_format))
 
     @property
     def element_type(self):

--- a/src/finch/finch_assembly/safe_buffer.py
+++ b/src/finch/finch_assembly/safe_buffer.py
@@ -1,0 +1,202 @@
+from .buffer import Buffer, BufferFormat
+
+
+class SafeBuffer(Buffer):
+    """
+    A wrapper buffer that adds bounds checking to any underlying buffer. Ensures
+    safe access to buffer elements by checking indices before load/store operations.
+    """
+
+    def __init__(self, underlying_buffer: Buffer):
+        """
+        Initialize SafeBuffer with an underlying buffer to wrap.
+
+        Args:
+            underlying_buffer: The buffer to add safety checks to
+        """
+        if not isinstance(underlying_buffer, Buffer):
+            raise TypeError(f"Expected Buffer instance, got {type(underlying_buffer)}")
+        self._underlying_buffer = underlying_buffer
+
+    @property
+    def format(self):
+        """
+        Returns the format of the safe buffer.
+        """
+        return SafeBufferFormat(self._underlying_buffer.format)
+
+    def length(self):
+        """
+        Return the length of the underlying buffer.
+        """
+        return self._underlying_buffer.length()
+
+    def _check_bounds(self, idx: int):
+        """
+        Check if the given index is within bounds.
+
+        Args:
+            idx: The index to check
+
+        Raises:
+            IndexError: If index is out of bounds
+            TypeError: If index is not an integer
+        """
+        if not isinstance(idx, int):
+            raise TypeError(f"Buffer indices must be integers, got {type(idx)}")
+
+        buffer_length = self.length()
+        if idx < 0:
+            # Handle negative indexing
+            idx = buffer_length + idx
+
+        if idx < 0 or idx >= buffer_length:
+            raise IndexError(
+                f"index {idx} is out of bounds for buffer of length {buffer_length}"
+            )
+
+        return idx
+
+    def load(self, idx: int):
+        """
+        Load an element from the buffer with bounds checking.
+
+        Args:
+            idx: The index to load from
+
+        Returns:
+            The element at the given index
+
+        Raises:
+            IndexError: If index is out of bounds
+        """
+        checked_idx = self._check_bounds(idx)
+        return self._underlying_buffer.load(checked_idx)
+
+    def store(self, idx: int, val):
+        """
+        Store an element in the buffer with bounds checking.
+
+        Args:
+            idx: The index to store at
+            val: The value to store
+
+        Raises:
+            IndexError: If index is out of bounds
+        """
+        checked_idx = self._check_bounds(idx)
+        self._underlying_buffer.store(checked_idx, val)
+
+    def resize(self, new_length: int):
+        """
+        Resize the underlying buffer.
+
+        Args:
+            new_length: The new length for the buffer
+
+        Raises:
+            ValueError: If new_length is negative
+            TypeError: If new_length is not an integer
+        """
+        if not isinstance(new_length, int):
+            raise TypeError(f"Buffer length must be an integer, got {type(new_length)}")
+
+        if new_length < 0:
+            raise ValueError(f"Buffer length must be non-negative, got {new_length}")
+
+        self._underlying_buffer.resize(new_length)
+
+    @property
+    def underlying_buffer(self):
+        """
+        Provide access to the underlying buffer for advanced use cases.
+        """
+        return self._underlying_buffer
+
+
+class SafeBufferFormat(BufferFormat):
+    """
+    A format for SafeBuffer that wraps another buffer format.
+    """
+
+    def __init__(self, underlying_format: BufferFormat):
+        """
+        Initialize with the underlying buffer format to wrap.
+
+        Args:
+            underlying_format: The buffer format to add safety to
+        """
+        if not isinstance(underlying_format, BufferFormat):
+            raise TypeError(
+                f"Expected BufferFormat instance, got {type(underlying_format)}"
+            )
+        self._underlying_format = underlying_format
+
+    def __eq__(self, other):
+        if not isinstance(other, SafeBufferFormat):
+            return False
+        return self._underlying_format == other._underlying_format
+
+    def __hash__(self):
+        return hash(("SafeBufferFormat", self._underlying_format))
+
+    @property
+    def element_type(self):
+        """
+        Return the element type of the underlying format.
+        """
+        return self._underlying_format.element_type
+
+    @property
+    def length_type(self):
+        """
+        Return the length type of the underlying format.
+        """
+        return self._underlying_format.length_type
+
+    def __call__(self, *args, **kwargs):
+        """
+        Create a SafeBuffer wrapping a buffer created by the underlying format.
+
+        Args:
+            *args: Arguments to pass to the underlying format
+            **kwargs: Keyword arguments to pass to the underlying format
+
+        Returns:
+            A SafeBuffer instance wrapping the created buffer
+        """
+        underlying_buffer = self._underlying_format(*args, **kwargs)
+        return SafeBuffer(underlying_buffer)
+
+    @property
+    def underlying_format(self):
+        """
+        Provide access to the underlying format.
+        """
+        return self._underlying_format
+
+
+def make_safe(buffer: Buffer) -> SafeBuffer:
+    """
+    Convenience function to wrap any buffer in a SafeBuffer.
+
+    Args:
+        buffer: The buffer to make safe
+
+    Returns:
+        A SafeBuffer wrapping the input buffer
+
+    Example:
+        >>> import numpy as np
+        >>> from finch.codegen import NumpyBuffer
+        >>> from finch.finch_assembly.safe_buffer import make_safe
+        >>> # Create a regular buffer
+        >>> arr = np.array([1, 2, 3, 4])
+        >>> buf = NumpyBuffer(arr)
+        >>> # Make it safe
+        >>> safe_buf = make_safe(buf)
+        >>> # Now bounds checking is automatic
+        >>> safe_buf.load(0)  # OK
+        >>> safe_buf.load(10)  # Raises IndexError
+    """
+    return SafeBuffer(buffer)

--- a/tests/buffers/test_safe_buffer.py
+++ b/tests/buffers/test_safe_buffer.py
@@ -1,0 +1,68 @@
+import pytest
+
+import numpy as np
+
+from finch.codegen import NumpyBuffer, NumpyBufferFormat
+from finch.finch_assembly import (
+    SafeBufferFormat,
+    make_safe,
+)
+
+
+@pytest.mark.parametrize(
+    "array_data, valid_indices, invalid_indices",
+    [
+        ([1, 2, 3, 4], [0, 1, 2, 3, -1, -2, -3, -4], [4, -5, 10]),
+        ([42], [0, -1], [1, -2, 5]),
+        ([], [], [0, -1, 1]),
+    ],
+)
+def test_safe_buffer_bounds_checking(array_data, valid_indices, invalid_indices):
+    arr = np.array(array_data, dtype=np.float64)
+    numpy_buf = NumpyBuffer(arr)
+    safe_buf = make_safe(numpy_buf)
+
+    # Test valid indices work
+    for idx in valid_indices:
+        # load check
+        expected_value = numpy_buf.load(idx)
+        if expected_value is not None:
+            assert safe_buf.load(idx) == expected_value
+        # store check
+        safe_buf.store(idx, 99.0)
+        assert safe_buf.load(idx) == 99.0
+
+    # Test invalid indices raise IndexError
+    for idx in invalid_indices:
+        with pytest.raises(IndexError, match="out of bounds"):
+            safe_buf.load(idx)
+
+        with pytest.raises(IndexError, match="out of bounds"):
+            safe_buf.store(idx, 99.0)
+
+    # Test format
+    assert safe_buf.format.element_type == numpy_buf.format.element_type
+    assert safe_buf.format.length_type == numpy_buf.format.length_type
+    assert safe_buf.format == SafeBufferFormat(numpy_buf.format)
+    assert safe_buf.format.underlying_format == numpy_buf.format
+
+
+def test_safe_buffer_format_call():
+    fmt = NumpyBufferFormat(dtype=np.int32)
+    safe_fmt = SafeBufferFormat(fmt)
+    assert safe_fmt(
+        len=5, dtype=np.int32
+    ).underlying_buffer.format == NumpyBufferFormat(np.int32)
+
+
+def test_resize_safe_buffer():
+    arr = np.array([1, 2, 3], dtype=np.float64)
+    numpy_buf = NumpyBuffer(arr)
+    safe_buf = make_safe(numpy_buf)
+
+    # Resize to a larger size
+    safe_buf.resize(5)
+    assert safe_buf.length() == 5
+    numpy_buf.resize(5)
+    assert isinstance(safe_buf.underlying_buffer, NumpyBuffer)
+    assert np.array_equal(safe_buf.underlying_buffer.arr, numpy_buf.arr)

--- a/tests/buffers/test_safe_buffer.py
+++ b/tests/buffers/test_safe_buffer.py
@@ -2,9 +2,9 @@ import pytest
 
 import numpy as np
 
-from finch.codegen import NumpyBuffer, NumpyBufferFormat
+from finch.codegen import NumpyBuffer, NumpyBufferFType
 from finch.finch_assembly import (
-    SafeBufferFormat,
+    SafeBufferFType,
     make_safe,
 )
 
@@ -41,18 +41,18 @@ def test_safe_buffer_bounds_checking(array_data, valid_indices, invalid_indices)
             safe_buf.store(idx, 99.0)
 
     # Test format
-    assert safe_buf.format.element_type == numpy_buf.format.element_type
-    assert safe_buf.format.length_type == numpy_buf.format.length_type
-    assert safe_buf.format == SafeBufferFormat(numpy_buf.format)
-    assert safe_buf.format.underlying_format == numpy_buf.format
+    assert safe_buf.ftype.element_type == numpy_buf.ftype.element_type
+    assert safe_buf.ftype.length_type == numpy_buf.ftype.length_type
+    assert safe_buf.ftype == SafeBufferFType(numpy_buf.ftype)
+    assert safe_buf.ftype.underlying_format == numpy_buf.ftype
 
 
 def test_safe_buffer_format_call():
-    fmt = NumpyBufferFormat(dtype=np.int32)
-    safe_fmt = SafeBufferFormat(fmt)
-    assert safe_fmt(
-        len=5, dtype=np.int32
-    ).underlying_buffer.format == NumpyBufferFormat(np.int32)
+    fmt = NumpyBufferFType(dtype=np.int32)
+    safe_fmt = SafeBufferFType(fmt)
+    assert safe_fmt(len=5, dtype=np.int32).underlying_buffer.ftype == NumpyBufferFType(
+        np.int32
+    )
 
 
 def test_resize_safe_buffer():


### PR DESCRIPTION
TLDR: Introduces safe buffer with tests for better bound checking in buffers
Aims to resolve #62 


This pull request introduces a new safety wrapper for buffer operations in the Finch assembly layer, ensuring that all buffer accesses are bounds-checked. The main additions are the `SafeBuffer` and `SafeBufferFormat` classes, as well as a convenient `make_safe` function to wrap any buffer with safety checks. Comprehensive tests are also included to verify correct behavior and error handling.

**New buffer safety features:**
* Added `SafeBuffer` class to `src/finch/finch_assembly/safe_buffer.py`, which wraps any existing buffer and enforces bounds checking on all load and store operations, raising `IndexError` for out-of-bounds access.
* Introduced `SafeBufferFormat` class, allowing safe buffer formats to be composed and used interchangeably with existing buffer formats.

**Testing:**
* Added `tests/buffers/test_safe_buffer.py` with parameterized tests to verify correct bounds checking, format compatibility, and resizing behavior for safe buffers.