### PR TITLE
Support `ndim` in `suitable_rep`

### DIFF
--- a/src/finch/algebra/tensor.py
+++ b/src/finch/algebra/tensor.py
@@ -150,10 +150,7 @@ class NDArrayFType(TensorFType):
     def __eq__(self, other):
         if not isinstance(other, NDArrayFType):
             return False
-        return self._dtype == other._dtype and (
-            # TODO: Remove `0` once logic compiler supports ndim inference
-            self._ndim == other._ndim or self._ndim == 0 or other._ndim == 0
-        )
+        return self._dtype == other._dtype and self._ndim == other._ndim
 
     def __hash__(self):
         return hash((self._dtype, self._ndim))

--- a/src/finch/finch_logic/nodes.py
+++ b/src/finch/finch_logic/nodes.py
@@ -472,5 +472,7 @@ class PrinterContext(Context):
             case Subquery(lhs, arg):
                 self.exec(f"{feed}{self(lhs)} = {self(arg)}")
                 return self(lhs)
+            case str(label):
+                return label
             case _:
                 raise ValueError(f"Unknown expression type: {type(prgm)}")

--- a/src/finch/finch_notation/interpreter.py
+++ b/src/finch/finch_notation/interpreter.py
@@ -195,17 +195,9 @@ def np_declare(tns, init, op, shape):
                 f"Invalid dimension start value {dim.start} for ndarray declaration."
             )
     shape = tuple(dim.end for dim in shape)
-
+    tns.fill(init)
     if tns.shape != shape:
-        if tns.shape == ():
-            tns = np.full(shape, init, tns.dtype)
-        else:
-            raise ValueError(
-                f"Shape mismatch: cannot resize numpy array. Expected {shape},"
-                f" got {tns.shape} for ndarray declaration."
-            )
-    else:
-        tns.fill(init)
+        tns = np.broadcast_to(tns, shape).copy()
     return tns
 
 

--- a/tests/test_logic_compiler.py
+++ b/tests/test_logic_compiler.py
@@ -113,7 +113,7 @@ def test_logic_compiler():
                 args=(
                     Variable(name=":A0", type_=NDArrayFType(np.dtype(int), 2)),
                     Variable(name=":A1", type_=NDArrayFType(np.dtype(int), 2)),
-                    Variable(name=":A2", type_=NDArrayFType(np.dtype(int), 0)),
+                    Variable(name=":A2", type_=NDArrayFType(np.dtype(int), 2)),
                 ),
                 body=Block(
                     bodies=(
@@ -165,12 +165,12 @@ def test_logic_compiler():
                             Variable(name=":A1", type_=NDArrayFType(np.dtype(int), 2)),
                         ),
                         Unpack(
-                            Slot(name=":A2_slot", type=NDArrayFType(np.dtype(int), 0)),
-                            Variable(name=":A2", type_=NDArrayFType(np.dtype(int), 0)),
+                            Slot(name=":A2_slot", type=NDArrayFType(np.dtype(int), 2)),
+                            Variable(name=":A2", type_=NDArrayFType(np.dtype(int), 2)),
                         ),
                         Declare(
                             tns=Slot(
-                                name=":A2_slot", type=NDArrayFType(np.dtype(int), 0)
+                                name=":A2_slot", type=NDArrayFType(np.dtype(int), 2)
                             ),
                             init=Literal(val=0),
                             op=Literal(val=operator.add),
@@ -195,7 +195,7 @@ def test_logic_compiler():
                                                     tns=Slot(
                                                         name=":A2_slot",
                                                         type=NDArrayFType(
-                                                            np.dtype(int), 0
+                                                            np.dtype(int), 2
                                                         ),
                                                     ),
                                                     mode=Update(
@@ -261,7 +261,7 @@ def test_logic_compiler():
                         ),
                         Freeze(
                             tns=Slot(
-                                name=":A2_slot", type=NDArrayFType(np.dtype(int), 0)
+                                name=":A2_slot", type=NDArrayFType(np.dtype(int), 2)
                             ),
                             op=Literal(val=operator.add),
                         ),
@@ -283,15 +283,15 @@ def test_logic_compiler():
                         ),
                         Repack(
                             val=Slot(
-                                name=":A2_slot", type=NDArrayFType(np.dtype(int), 0)
+                                name=":A2_slot", type=NDArrayFType(np.dtype(int), 2)
                             ),
                             obj=Variable(
-                                name=":A2", type_=NDArrayFType(np.dtype(int), 0)
+                                name=":A2", type_=NDArrayFType(np.dtype(int), 2)
                             ),
                         ),
                         Return(
                             val=Variable(
-                                name=":A2", type_=NDArrayFType(np.dtype(int), 0)
+                                name=":A2", type_=NDArrayFType(np.dtype(int), 2)
                             )
                         ),
                     )


### PR DESCRIPTION
Some follow-up cleanup PR: Now instead of hardcoded `ndim=0` for the inferred NDArray type, the `ndim` property shoud be accurate. 