### PR TITLE
Fixed annihilator bitwise properties

### DIFF
--- a/src/finch/algebra/algebra.py
+++ b/src/finch/algebra/algebra.py
@@ -362,7 +362,7 @@ register_property(
     "is_identity",
     lambda op, val: (isinstance(val, bool | np.bool_) and not bool(val))
     or (
-        isinstance(val | int) and not isinstance(val, bool | np.bool_) and int(val) == 0
+        isinstance(val, int) and not isinstance(val, bool | np.bool_) and int(val) == 0
     ),
 )
 register_property(

--- a/src/finch/algebra/algebra.py
+++ b/src/finch/algebra/algebra.py
@@ -357,19 +357,29 @@ def is_identity(op: Any, val: Any) -> bool:
 register_property(operator.add, "__call__", "is_identity", lambda op, val: val == 0)
 register_property(operator.mul, "__call__", "is_identity", lambda op, val: val == 1)
 register_property(
-    operator.or_, "__call__", "is_identity",
-    lambda op, val: (isinstance(val, (bool, np.bool_)) and not bool(val))
-                    or (isinstance(val, int) and not isinstance(val, (bool, np.bool_)) and int(val) == 0)
+    operator.or_,
+    "__call__",
+    "is_identity",
+    lambda op, val: (isinstance(val, bool | np.bool_) and not bool(val))
+    or (
+        isinstance(val | int) and not isinstance(val, bool | np.bool_) and int(val) == 0
+    ),
 )
 register_property(
-    operator.and_, "__call__", "is_identity",
-    lambda op, val: (isinstance(val, (bool, np.bool_)) and bool(val))
-                    or (isinstance(val, int) and not isinstance(val, bool) and int(val) == -1)
+    operator.and_,
+    "__call__",
+    "is_identity",
+    lambda op, val: (isinstance(val, bool | np.bool_) and bool(val))
+    or (isinstance(val, int) and not isinstance(val, bool) and int(val) == -1),
 )
 register_property(
-    operator.xor, "__call__", "is_identity",
-    lambda op, val: (isinstance(val, (bool, np.bool_)) and not bool(val))
-                    or (isinstance(val, int) and not isinstance(val, (bool, np.bool_)) and int(val) == 0)
+    operator.xor,
+    "__call__",
+    "is_identity",
+    lambda op, val: (isinstance(val, bool | np.bool_) and not bool(val))
+    or (
+        isinstance(val, int) and not isinstance(val, bool | np.bool_) and int(val) == 0
+    ),
 )
 register_property(operator.truediv, "__call__", "is_identity", lambda op, val: val == 1)
 register_property(operator.lshift, "__call__", "is_identity", lambda op, val: val == 0)
@@ -378,14 +388,16 @@ register_property(operator.pow, "__call__", "is_identity", lambda op, val: val =
 register_property(
     np.logaddexp, "__call__", "is_identity", lambda op, val: val == -math.inf
 )
-register_property(np.logical_and, "__call__", "is_identity",
-                  lambda op, val: bool(val))
+register_property(np.logical_and, "__call__", "is_identity", lambda op, val: bool(val))
 
-register_property(np.logical_or, "__call__", "is_identity",
-                  lambda op, val: not bool(val))
+register_property(
+    np.logical_or, "__call__", "is_identity", lambda op, val: not bool(val)
+)
 
-register_property(np.logical_xor, "__call__", "is_identity",
-                  lambda op, val: not bool(val))
+register_property(
+    np.logical_xor, "__call__", "is_identity", lambda op, val: not bool(val)
+)
+
 
 def is_distributive(op, other_op):
     """
@@ -445,6 +457,7 @@ register_property(
     lambda op, other_op: False,
 )
 
+
 def is_annihilator(op, val):
     """
     Returns whether the given object is an annihilator for the given function, that is,
@@ -462,15 +475,30 @@ def is_annihilator(op, val):
 
 for fn, func in [
     (operator.mul, lambda op, val: val == 0),
-    (operator.or_, lambda op, val: (isinstance(val, (bool, np.bool_)) and bool(val))
-                     or (isinstance(val, int) and not isinstance(val, (bool, np.bool_)) and int(val) == -1)),
-    (operator.and_, lambda op, val:(isinstance(val, (bool, np.bool_)) and not bool(val))
-                     or (isinstance(val, int) and not isinstance(val, (bool, np.bool_)) and int(val) == 0)),
+    (
+        operator.or_,
+        lambda op, val: (isinstance(val, bool | np.bool_) and bool(val))
+        or (
+            isinstance(val, int)
+            and not isinstance(val, bool | np.bool_)
+            and int(val) == -1
+        ),
+    ),
+    (
+        operator.and_,
+        lambda op, val: (isinstance(val, bool | np.bool_) and not bool(val))
+        or (
+            isinstance(val, int)
+            and not isinstance(val, bool | np.bool_)
+            and int(val) == 0
+        ),
+    ),
     (np.logaddexp, lambda op, val: val == math.inf),
     (np.logical_and, lambda op, val: not bool(val)),
     (np.logical_or, lambda op, val: bool(val)),
 ]:
     register_property(fn, "__call__", "is_annihilator", func)
+
 
 def fixpoint_type(op: Any, z: Any, t: type) -> type:
     """
@@ -570,6 +598,7 @@ for op in [operator.add, operator.mul, operator.and_, operator.xor, operator.or_
         "init_value",
         lambda op, arg, meth=meth: query_property(arg, meth, "init_value"),
     )
+
 
 def sum_init_value(t):
     if t is bool:

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -11,6 +11,7 @@ from finch.algebra import (
     is_identity,
 )
 
+
 def test_algebra_selected():
     assert is_distributive(operator.mul, operator.add)
     assert is_distributive(operator.mul, operator.sub)
@@ -57,7 +58,7 @@ def test_bitwise_properties_bools_and_ints():
     assert is_annihilator(operator.and_, 0)
     assert is_annihilator(operator.or_, -1)
     assert init_value(operator.and_, int) == -1
-    assert init_value(operator.or_,  int) == 0
+    assert init_value(operator.or_, int) == 0
     assert init_value(operator.xor, int) == 0
     assert init_value(operator.and_, bool) is True
     assert init_value(operator.or_, bool) is False

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -11,7 +11,6 @@ from finch.algebra import (
     is_identity,
 )
 
-
 def test_algebra_selected():
     assert is_distributive(operator.mul, operator.add)
     assert is_distributive(operator.mul, operator.sub)
@@ -21,19 +20,13 @@ def test_algebra_selected():
     assert is_distributive(np.logical_and, np.logical_or)
     assert is_distributive(np.logical_and, np.logical_xor)
     assert is_distributive(np.logical_or, np.logical_and)
-    assert is_annihilator(operator.add, math.inf)
     assert is_annihilator(operator.mul, 0)
-    assert is_annihilator(operator.or_, True)
-    assert is_annihilator(operator.and_, False)
     assert is_annihilator(np.logaddexp, math.inf)
     assert is_annihilator(np.logical_or, True)
     assert is_annihilator(np.logical_and, False)
     assert is_identity(operator.add, 0)
     assert is_identity(operator.mul, 1)
-    assert is_identity(operator.or_, False)
-    assert is_identity(operator.and_, True)
     assert is_identity(operator.truediv, 1)
-    assert is_identity(operator.floordiv, 1)
     assert is_identity(operator.lshift, 0)
     assert is_identity(operator.rshift, 0)
     assert is_identity(operator.pow, 1)
@@ -46,10 +39,26 @@ def test_algebra_selected():
     assert is_associative(np.logical_xor)
     assert is_associative(np.logical_or)
     assert is_associative(np.logaddexp)
-    assert init_value(operator.and_, bool) is True
-    assert init_value(operator.or_, bool) is False
-    assert init_value(operator.xor, bool) is False
     assert init_value(np.logaddexp, float) == -math.inf
     assert init_value(np.logical_and, bool) is True
     assert init_value(np.logical_or, bool) is False
     assert init_value(np.logical_xor, bool) is False
+
+
+def test_bitwise_properties_bools_and_ints():
+    assert is_identity(operator.or_, False)
+    assert is_identity(operator.and_, True)
+    assert is_identity(operator.xor, False)
+    assert is_identity(operator.or_, 0)
+    assert is_identity(operator.and_, -1)
+    assert is_identity(operator.xor, 0)
+    assert is_annihilator(operator.and_, False)
+    assert is_annihilator(operator.or_, True)
+    assert is_annihilator(operator.and_, 0)
+    assert is_annihilator(operator.or_, -1)
+    assert init_value(operator.and_, int) == -1
+    assert init_value(operator.or_,  int) == 0
+    assert init_value(operator.xor, int) == 0
+    assert init_value(operator.and_, bool) is True
+    assert init_value(operator.or_, bool) is False
+    assert init_value(operator.xor, bool) is False


### PR DESCRIPTION
Hi all,
I’ve fixed the bitwise annihilator issue and clarified the distinction between is_identity and is_annihilator:
- If the value is a number (int), we use bitwise semantics.
- If the value is a boolean, we use boolean semantics (truthiness).

For init_value changes, I used -1 instead of True for bitwise_and . True casts to 1, which isn’t the identity for &, while -1 ensures x & -1 == x; and bool(-1) is True, so it behaves correctly for booleans too.

I currently require np.bool_ for boolean paths, but for integers I limited support to Python int and did not include np.integer  as NumPy has many integer dtypes. I’d appreciate guidance on whether we should keep the policy as Python int only, or
support np.integer as well.

Other cleanups while editing algebra.py:
1. Removed operator.add from is_annihilator: +∞ is not an annihilator “for all a” (e.g., (+∞) + (−∞) = NaN).
2. Removed floor division (//) from is_identity: there’s no universal identity (e.g., 3.2 // 1 -> 3.0 ≠ 3.2).

Fixes #73 
