### PR TITLE
fix: implement BufferLoop printing in AssemblyPrinterContext

### DIFF
--- a/src/finchlite/finch_assembly/nodes.py
+++ b/src/finchlite/finch_assembly/nodes.py
@@ -637,10 +637,12 @@ class AssemblyPrinterContext(Context):
                 self.exec(f"{feed}for {var_2} in range({start}, {end}):\n{body_code}")
                 return None
             case BufferLoop(buf, var, body):
+                var_2 = self(var)
+                buf_2 = self(buf)
                 ctx_2 = self.subblock()
                 ctx_2(body)
                 body_code = ctx_2.emit()
-                self.exec(f"{feed}for {var} in {buf}: \n{body_code}")
+                self.exec(f"{feed}for {var_2} in {buf_2}: \n{body_code}")
                 return None
             case WhileLoop(cond, body):
                 cond_code = self(cond)


### PR DESCRIPTION
In /finch-tensor-lite/src/finchlite/finch_assembly/nodes.py, in the AssemblyPrinterContext class, case for BufferLoop was not implemented