### PR TITLE
Testing for Safe Buffers

### DIFF
--- a/src/finchlite/codegen/safe_buffer.py
+++ b/src/finchlite/codegen/safe_buffer.py
@@ -68,11 +68,10 @@ class SafeBufferFType(CBufferFType, NumbaBufferFType, CStackFType, NumbaStackFTy
         idx_n = ctx.freshen("computed")
         ctx.exec(
             f"{ctx.feed}size_t {idx_n} = ({ctx(idx)});\n"
-            f"{ctx.feed}if ({idx_n} < 0 || {idx_n} >= ({self.c_length(ctx, buf)}))"
-            "{"
-            f'fprintf(stderr, "Encountered an index out of bounds error!");\n'
-            f"exit(1);\n"
-            "}"
+            f"{ctx.feed}if ({idx_n} < 0 || {idx_n} >= ({self.c_length(ctx, buf)})) {{\n"
+            f'{ctx.feed}    fprintf(stderr, "Encountered an index out of bounds error!");\n'
+            f"{ctx.feed}    exit(1);\n"
+            f"{ctx.feed}}}"
         )
         return asm.Variable(idx_n, ctypes.c_size_t)
 

--- a/tests/reference/test_safe_loadstore_regression_compiler0__c_.c
+++ b/tests/reference/test_safe_loadstore_regression_compiler0__c_.c
@@ -1,0 +1,41 @@
+#include <stddef.h>
+typedef void* (*fptr)( void**, size_t );
+struct CNumpyBuffer {
+    void* arr;
+    void* data;
+    size_t length;
+    fptr resize;
+};
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+ssize_t finch_access(struct CNumpyBuffer* a, size_t idx) {
+    struct CNumpyBuffer* a_ = a;
+    ssize_t* a__data = (ssize_t*)a_->data;
+    size_t a__length = a_->length;
+    size_t computed = (idx);
+    if (computed < 0 || computed >= (a__length)) {
+        fprintf(stderr, "Encountered an index out of bounds error!");
+        exit(1);
+    }
+    ssize_t val = (a__data)[computed];
+    size_t computed_2 = (idx);
+    if (computed_2 < 0 || computed_2 >= (a__length)) {
+        fprintf(stderr, "Encountered an index out of bounds error!");
+        exit(1);
+    }
+    ssize_t val2 = (a__data)[computed_2];
+    return val;
+}
+ssize_t finch_change(struct CNumpyBuffer* a, size_t idx, ssize_t val) {
+    struct CNumpyBuffer* a_ = a;
+    ssize_t* a__data_2 = (ssize_t*)a_->data;
+    size_t a__length_2 = a_->length;
+    size_t computed_3 = (idx);
+    if (computed_3 < 0 || computed_3 >= (a__length_2)) {
+        fprintf(stderr, "Encountered an index out of bounds error!");
+        exit(1);
+    }
+    (a__data_2)[computed_3] = val;
+    return (ssize_t)0;
+}

--- a/tests/reference/test_safe_loadstore_regression_compiler1__py_.py
+++ b/tests/reference/test_safe_loadstore_regression_compiler1__py_.py
@@ -1,0 +1,28 @@
+import _operator, builtins
+from numba import njit
+import numpy
+
+
+@njit
+def finch_access(a: builtins.list, idx: ctypes.c_ulong) -> numpy.int64:
+    a_ = a
+    a__arr = a_[0]
+    computed = (idx)
+    if computed < 0 or computed >= (len(a__arr)):
+        raise IndexError()
+    val: numpy.int64 = a__arr[computed]
+    computed_2 = (idx)
+    if computed_2 < 0 or computed_2 >= (len(a__arr)):
+        raise IndexError()
+    val2: numpy.int64 = a__arr[computed_2]
+    return val
+
+@njit
+def finch_change(a: builtins.list, idx: ctypes.c_ulong, val: ctypes.c_long) -> numpy.int64:
+    a_ = a
+    a__arr_2 = a_[0]
+    computed_3 = (idx)
+    if computed_3 < 0 or computed_3 >= (len(a__arr_2)):
+        raise IndexError()
+    a__arr_2[computed_3] = val
+    return c_long(0)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -472,34 +472,10 @@ def test_c_load_safebuffer(size, idx):
     [
         (*params, compiler)
         for params in [
-            (
-                -1,
-                2,
-            ),
-            (
-                -1,
-                3,
-            ),
-            (
-                0,
-                2,
-            ),
-            (
-                1,
-                2,
-            ),
-            (
-                2,
-                3,
-            ),
-            (
-                2,
-                2,
-            ),
-            (
-                3,
-                2,
-            ),
+            (-1, 2),
+            (1, 2),
+            (2, 3),
+            (2, 2),
         ]
         for compiler in [asm.AssemblyInterpreter(), NumbaCompiler()]
     ],
@@ -548,12 +524,9 @@ def test_numba_load_safebuffer(size, idx, compiler):
         (*params, compiler)
         for params in [
             (-1, 2, 3),
-            (-1, 3, 1434),
-            (0, 2, 3),
-            (1, 2, 3),
-            (2, 3, 3),
+            (1, 2, 1434),
+            (2, 3, 1434),
             (2, 2, 3),
-            (3, 2, 3),
         ]
         for compiler in [NumbaCompiler(), asm.AssemblyInterpreter()]
     ],
@@ -599,34 +572,10 @@ def test_numba_store_safebuffer(size, idx, value, compiler):
     [
         (*params, value)
         for params in [
-            (
-                -1,
-                2,
-            ),
-            (
-                -1,
-                3,
-            ),
-            (
-                0,
-                2,
-            ),
-            (
-                1,
-                2,
-            ),
-            (
-                2,
-                3,
-            ),
-            (
-                2,
-                2,
-            ),
-            (
-                3,
-                2,
-            ),
+            ( -1, 2),
+            ( 1, 2),
+            ( 2, 3),
+            ( 2, 2),
         ]
         for value in [-1, 1434]
     ],
@@ -663,9 +612,7 @@ def test_c_store_safebuffer(size, idx, value):
     "value,np_type,c_type",
     [
         (3, np.int64, ctypes.c_int64),
-        (2, np.int32, ctypes.c_int32),
         (1, np.float32, ctypes.c_float),
-        (1.0, np.float64, ctypes.c_double),
         (1.2, np.float64, ctypes.c_double),
     ],
 )
@@ -682,9 +629,7 @@ def test_np_c_serialization(value, np_type, c_type):
     "value,c_type",
     [
         (3, ctypes.c_int64),
-        (2, ctypes.c_int32),
         (1, ctypes.c_float),
-        (1.0, ctypes.c_double),
         (1.2, ctypes.c_double),
     ],
 )
@@ -702,9 +647,7 @@ def test_ctypes_c_serialization(value, c_type):
     "value,np_type",
     [
         (3, np.int64),
-        (2, np.int32),
         (1, np.float32),
-        (1.0, np.float64),
         (1.2, np.float64),
     ],
 )


### PR DESCRIPTION
Adds some requested changes to safebuffers testing:

1. Reduced test cases for index accessing
2. Added regression testing for codegen involving buffer access