### PR TITLE
Simple debugging infra

### DIFF
--- a/src/finchlite/autoschedule/formatter.py
+++ b/src/finchlite/autoschedule/formatter.py
@@ -1,17 +1,20 @@
-import numpy as np
+from typing import Any
 
-from finchlite.finch_assembly import AssemblyLibrary
-from finchlite.finch_logic.nodes import TableValueFType
+import numpy as np
 
 from .. import finch_logic as lgc
 from ..codegen import NumpyBufferFType
 from ..compile import BufferizedNDArrayFType
-from ..finch_assembly import TupleFType
-from ..finch_logic import LogicLoader, MockLogicLoader
+from ..finch_assembly import AssemblyLibrary, TupleFType
+from ..finch_logic import LogicLoader, MockLogicLoader, TableValueFType
 from ..symbolic import gensym
 
 
 class LogicFormatter(LogicLoader):
+    """
+    Docstring for LogicFormatter
+    """
+
     def __init__(self, loader: LogicLoader | None = None):
         super().__init__()
         if loader is None:
@@ -22,6 +25,8 @@ class LogicFormatter(LogicLoader):
         self,
         prgm: lgc.LogicStatement,
         bindings: dict[lgc.Alias, lgc.TableValueFType],
+        *,
+        debug_ctx: dict[str, Any] | None = None,
     ) -> tuple[
         AssemblyLibrary, lgc.LogicStatement, dict[lgc.Alias, lgc.TableValueFType]
     ]:

--- a/src/finchlite/autoschedule/normalize.py
+++ b/src/finchlite/autoschedule/normalize.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ..finch_logic import (
     Alias,
     Field,
@@ -13,7 +15,11 @@ class LogicNormalizer(LogicEvaluator):
         self.ctx: LogicEvaluator = ctx
 
     def __call__(
-        self, prgm: LogicNode, bindings: dict[Alias, TableValue] | None = None
+        self,
+        prgm: LogicNode,
+        bindings: dict[Alias, TableValue] | None = None,
+        *,
+        debug_ctx: dict[str, Any] | None = None,
     ) -> TableValue | tuple[TableValue, ...]:
         if bindings is None:
             bindings = {}
@@ -51,7 +57,7 @@ class LogicNormalizer(LogicEvaluator):
         bindings = {
             Rewrite(rule_0)(var): reidx(tbl, renames) for var, tbl in bindings.items()
         }
-        res = self.ctx(root, bindings)
+        res = self.ctx(root, bindings, debug_ctx=debug_ctx)
 
         if isinstance(res, tuple):
             return tuple(reidx(tbl, unrenames) for tbl in res)

--- a/src/finchlite/autoschedule/optimize.py
+++ b/src/finchlite/autoschedule/optimize.py
@@ -4,8 +4,7 @@ from functools import reduce
 from itertools import chain as join_chains
 from typing import overload
 
-from finchlite.algebra.algebra import is_annihilator, is_distributive, is_identity
-
+from ..algebra import is_annihilator, is_distributive, is_identity
 from ..finch_logic import (
     Aggregate,
     Alias,
@@ -61,9 +60,6 @@ def optimize(prgm: LogicNode) -> LogicNode:
     prgm = concordize(prgm)
 
     prgm = materialize_squeeze_expand_productions(prgm)
-    prgm = propagate_copy_queries(prgm)
-
-    # prgm = propagate_into_reformats(prgm)
     prgm = propagate_copy_queries(prgm)
 
     return normalize_names(prgm)
@@ -276,46 +272,6 @@ def propagate_copy_queries(root):
                 return Plan()
 
     return Rewrite(PostWalk(Chain([lambda node: copies.get(node), rule_0])))(root)
-
-
-# def propagate_into_reformats(root: LogicNode) -> LogicNode:
-#    @dataclass
-#    class Entry:
-#        node: Query
-#        node_pos: int
-#        matched: Query | None = None
-#        matched_pos: int | None = None
-#
-#    def rule_0(ex: LogicNode) -> LogicNode | None:
-#        match ex:
-#            case Plan(bodies):
-#                queries: list[Entry] = []
-#                for idx, node in enumerate(bodies):
-#                    match node:
-#                        case Query(_, Reformat(_, arg)) as que_ref:
-#                            for q in queries[::-1]:
-#                                if q.node.lhs == arg:
-#                                    q.matched = que_ref
-#                                    q.matched_pos = idx
-#                                    break
-#                        case Query(_, _) as q:
-#                            queries.append(Entry(q, idx))
-#
-#                for q in queries[::-1]:
-#                    if q.matched is not None and q.matched_pos is not None:
-#                        new_bodies = list(bodies)
-#                        new_bodies.pop(q.matched_pos)
-#                        if q.node.lhs not in PostOrderDFS(
-#                            Plan(tuple(new_bodies[q.node_pos + 1 :]))
-#                        ) and isinstance(q.node.rhs, MapJoin | Aggregate | Reorder):
-#                            assert isinstance(q.matched.rhs, Reformat)
-#                            new_bodies[q.node_pos] = Query(
-#                                q.matched.lhs, Reformat(q.matched.rhs.tns, q.node.rhs)
-#                            )
-#                            return Plan(tuple(new_bodies))
-#        return None
-#
-#    return Rewrite(PostWalk(Fixpoint(rule_0)))(root)
 
 
 @overload

--- a/src/finchlite/autoschedule/stages.py
+++ b/src/finchlite/autoschedule/stages.py
@@ -10,6 +10,5 @@ class LogicNotationLowerer(ABC):
         self, term: lgc.LogicStatement, bindings: dict[lgc.Alias, lgc.TableValueFType]
     ) -> ntn.Module:
         """
-        Generate Finch Notation from the given logic and input types.  Also
-        return a dictionary including additional tables needed to run the kernel.
+        Generate Finch Notation from the given logic and input types.
         """

--- a/src/finchlite/autoschedule/standardize.py
+++ b/src/finchlite/autoschedule/standardize.py
@@ -1,4 +1,5 @@
 from functools import reduce
+from typing import Any
 
 from ..algebra import overwrite
 from ..finch_logic import (
@@ -298,7 +299,16 @@ class LogicStandardizer(LogicLoader):
             ctx = MockLogicLoader()
         self.ctx = ctx
 
-    def __call__(self, prgm: LogicStatement, bindings):
+    def __call__(
+        self,
+        prgm: LogicStatement,
+        bindings: dict[Alias, TableValueFType],
+        *,
+        debug_ctx: dict[str, Any] | None = None,
+    ):
+        if debug_ctx is not None:
+            debug_ctx["pre_logic_standardizer"] = prgm
+
         prgm = isolate_aggregates(prgm)
         prgm = split_increments(prgm)
         prgm = standardize_query_roots(prgm, bindings)
@@ -307,4 +317,8 @@ class LogicStandardizer(LogicLoader):
         prgm = drop_with_aggregation(prgm, bindings)
         prgm = concordize(prgm, bindings)
         prgm = drop_reorders(prgm)
+
+        if debug_ctx is not None:
+            debug_ctx["post_logic_standardizer"] = prgm
+
         return self.ctx(prgm, bindings)

--- a/tests/test_logic_compiler.py
+++ b/tests/test_logic_compiler.py
@@ -12,15 +12,17 @@ from finchlite.finch_logic import (
     Aggregate,
     Alias,
     Field,
+    Literal,
     MapJoin,
     Plan,
     Produces,
     Query,
     Relabel,
     Reorder,
+    Table,
     TableValue,
 )
-from finchlite.interface import INTERPRET_NOTATION
+from finchlite.interface import INTERPRET_NOTATION, OPTIMIZE_LOGIC
 
 from .conftest import finch_assert_equal
 
@@ -90,3 +92,176 @@ def test_logic_compiler(file_regression):
     )
 
     finch_assert_equal(result[0].tns.to_numpy(), expected)
+
+
+def test_logic_compiler_pipeline():
+    plan = Plan(
+        bodies=(
+            Query(
+                lhs=Alias(name="#A#0"),
+                rhs=Table(
+                    tns=Literal(
+                        val=BufferizedNDArray(val=np.array([[1, 2, 3], [0, 2, 1]]))
+                    ),
+                    idxs=(Field(name="#i#1"), Field(name="#i#2")),
+                ),
+            ),
+            Query(
+                lhs=Alias(name="#A#3"),
+                rhs=Table(
+                    tns=Literal(
+                        val=BufferizedNDArray(val=np.array([[1, 2], [0, 3], [4, 0]]))
+                    ),
+                    idxs=(Field(name="#i#4"), Field(name="#i#5")),
+                ),
+            ),
+            Query(
+                lhs=Alias(name="#A#17"),
+                rhs=Reorder(
+                    arg=MapJoin(
+                        op=Literal(val=operator.mul),
+                        args=(
+                            Reorder(
+                                arg=Relabel(
+                                    arg=Reorder(
+                                        arg=Relabel(
+                                            arg=Alias(name="#A#0"),
+                                            idxs=(
+                                                Field(name="#i#6"),
+                                                Field(name="#i#7"),
+                                            ),
+                                        ),
+                                        idxs=(
+                                            Field(name="#i#6"),
+                                            Field(name="#i#7"),
+                                            Field(name="#i#8"),
+                                        ),
+                                    ),
+                                    idxs=(
+                                        Field(name="#i#12"),
+                                        Field(name="#i#13"),
+                                        Field(name="#j#15"),
+                                    ),
+                                ),
+                                idxs=(Field(name="#i#12"), Field(name="#i#13")),
+                            ),
+                            Reorder(
+                                arg=Relabel(
+                                    arg=Reorder(
+                                        arg=Relabel(
+                                            arg=Alias(name="#A#3"),
+                                            idxs=(
+                                                Field(name="#i#9"),
+                                                Field(name="#i#10"),
+                                            ),
+                                        ),
+                                        idxs=(
+                                            Field(name="#i#11"),
+                                            Field(name="#i#9"),
+                                            Field(name="#i#10"),
+                                        ),
+                                    ),
+                                    idxs=(
+                                        Field(name="#j#16"),
+                                        Field(name="#i#13"),
+                                        Field(name="#i#14"),
+                                    ),
+                                ),
+                                idxs=(Field(name="#i#13"), Field(name="#i#14")),
+                            ),
+                        ),
+                    ),
+                    idxs=(
+                        Field(name="#i#12"),
+                        Field(name="#i#13"),
+                        Field(name="#i#14"),
+                    ),
+                ),
+            ),
+            Query(
+                lhs=Alias(name="#A#21"),
+                rhs=Aggregate(
+                    op=Literal(val=operator.add),
+                    init=Literal(val=np.float64(0.0)),
+                    arg=Relabel(
+                        arg=Alias(name="#A#17"),
+                        idxs=(
+                            Field(name="#i#18"),
+                            Field(name="#i#19"),
+                            Field(name="#i#20"),
+                        ),
+                    ),
+                    idxs=(Field(name="#i#19"),),
+                ),
+            ),
+            Plan(bodies=()),
+            Query(lhs=Alias(name="#A#22"), rhs=Alias(name="#A#21")),
+            Produces(args=(Alias(name="#A#22"),)),
+        )
+    )
+
+    expected_plan = Plan(
+        bodies=(
+            Query(
+                lhs=Alias(name="A"),
+                rhs=Reorder(
+                    arg=Alias(name="A_11"), idxs=(Field(name="i"), Field(name="i_2"))
+                ),
+            ),
+            Query(
+                lhs=Alias(name="A_2"),
+                rhs=Reorder(
+                    arg=Alias(name="A_12"), idxs=(Field(name="i_3"), Field(name="i_4"))
+                ),
+            ),
+            Query(
+                lhs=Alias(name="#A#23"),
+                rhs=Aggregate(
+                    op=Literal(val=operator.add),
+                    init=Literal(val=np.float64(0.0)),
+                    arg=Relabel(
+                        arg=Reorder(
+                            arg=MapJoin(
+                                op=Literal(val=operator.mul),
+                                args=(
+                                    Relabel(
+                                        arg=Alias(name="A"),
+                                        idxs=(Field(name="i_8"), Field(name="i_9")),
+                                    ),
+                                    Relabel(
+                                        arg=Alias(name="A_2"),
+                                        idxs=(Field(name="i_9"), Field(name="i_15")),
+                                    ),
+                                ),
+                            ),
+                            idxs=(
+                                Field(name="i_8"),
+                                Field(name="i_9"),
+                                Field(name="i_15"),
+                            ),
+                        ),
+                        idxs=(
+                            Field(name="i_16"),
+                            Field(name="i_17"),
+                            Field(name="i_18"),
+                        ),
+                    ),
+                    idxs=(Field(name="i_17"),),
+                ),
+            ),
+            Query(
+                lhs=Alias(name="A_4"),
+                rhs=Reorder(
+                    arg=Alias(name="#A#23"),
+                    idxs=(Field(name="i_16"), Field(name="i_18")),
+                ),
+            ),
+            Produces(args=(Alias(name="A_4"),)),
+        )
+    )
+
+    ctx = OPTIMIZE_LOGIC
+    debug_ctx = {}
+    ctx(plan, debug_ctx=debug_ctx)
+
+    assert debug_ctx["post_logic_standardizer"] == expected_plan


### PR DESCRIPTION
Hi @willow-ahrens,

I'm in the middle of reviewing #251, and I'm working on dense levels kernel for matmul operation.

First thing I would like to clear out is the mismatch of matmul and sddmm kernels generated with optimizer now and before the refactor.

Unfortunately we didn't test it thoroughly enough (e.g. only testing the output result of running a kernel instead of the actual kernel generated where it made sense).

So first - for A @ B where the raw logic is:

```py
A = Table(BufferizedNDArray(shape=(np.int64(2), np.int64(3))), ["i", "i_2"])
A_2 = Table(
    BufferizedNDArray(shape=(np.int64(3), np.int64(2))), ["i_3", "i_4"]
)
A_3 = Reorder(
    MapJoin(
        mul,
        (
            Reorder(
                Relabel(
                    Reorder(Relabel(A, ["i_5", "i_6"]), ["i_5", "i_6", "i_7"]),
                    ["i_8", "i_9", "i_10"],
                ),
                ["i_8", "i_9"],
            ),
            Reorder(
                Relabel(
                    Reorder(
                        Relabel(A_2, ["i_11", "i_12"]),
                        ["i_13", "i_11", "i_12"],
                    ),
                    ["i_14", "i_9", "i_15"],
                ),
                ["i_9", "i_15"],
            ),
        ),
    ),
    ["i_8", "i_9", "i_15"],
)
A_4 = Aggregate(add, 0.0, Relabel(A_3, ["i_16", "i_17", "i_18"]), ["i_17"])

A_5 = A_4
return ("A_5",)
```

after logic optimization we get:
```py
A = Reorder(A_11, ["i", "i_2"])
A_2 = Reorder(A_12, ["i_3", "i_4"])
A_3 = Aggregate(
    overwrite,
    0,
    Reorder(
        MapJoin(
            mul,
            ("Relabel(A, ['i_8', 'i_9'])", "Relabel(A_2, ['i_9', 'i_15'])"),
        ),
        ["i_8", "i_9", "i_15"],
    ),
    [],
)
A0 = Aggregate(
    add,
    0.0,
    Reorder(Relabel(A_3, ["i_16", "i_17", "i_18"]), ["i_16", "i_17", "i_18"]),
    ["i_17"],
)
A_4 = Reorder(A0, ["i_16", "i_18"])
A_5 = Reorder(A_4, ["i_16", "i_18"])
return ("A_5",)
```
which results in multiple `loop(loop(...))` for each input table only for `overwrite`.

Can we get rid of aggregate with overwrite?


Here is an expandable section with notation prgm from `NotationCompiler`:
<details>

```
def main(#A_11#7: BufferizedNDArray_i64_shape_i64_i64_strides_i64_i64, #A_12#11: BufferizedNDArray_i64_shape_i64_i64_strides_i64_i64, #A#15: BufferizedNDArray_i64_shape_i64_i64_strides_i64_i64, #A_2#19: BufferizedNDArray_i64_shape_i64_i64_strides_i64_i64, #A_3#23: BufferizedNDArray_i64_shape_i64_i64_i64_strides_i64_i64_i64, ##A#0#28: BufferizedNDArray_f64_shape_i64_i64_strides_i64_i64, #A_4#32: BufferizedNDArray_f64_shape_i64_i64_strides_i64_i64, #A_5#36: BufferizedNDArray_f64_shape_i64_i64_strides_i64_i64) -> tuple(BufferizedNDArray_f64_shape_i64_i64_strides_i64_i64):
    #_A_11#8: BufferizedNDArray_i64_shape_i64_i64_strides_i64_i64 = unpack(#A_11#7)
    #A_11_dim_0#9: int64 = #_A_11#8.shape[0]
    #A_11_dim_1#10: int64 = #_A_11#8.shape[1]
    #_A_12#12: BufferizedNDArray_i64_shape_i64_i64_strides_i64_i64 = unpack(#A_12#11)
    #A_12_dim_0#13: int64 = #_A_12#12.shape[0]
    #A_12_dim_1#14: int64 = #_A_12#12.shape[1]
    #_A#16: BufferizedNDArray_i64_shape_i64_i64_strides_i64_i64 = unpack(#A#15)
    #A_dim_0#17: int64 = #_A#16.shape[0]
    #A_dim_1#18: int64 = #_A#16.shape[1]
    #_A_2#20: BufferizedNDArray_i64_shape_i64_i64_strides_i64_i64 = unpack(#A_2#19)
    #A_2_dim_0#21: int64 = #_A_2#20.shape[0]
    #A_2_dim_1#22: int64 = #_A_2#20.shape[1]
    #_A_3#24: BufferizedNDArray_i64_shape_i64_i64_i64_strides_i64_i64_i64 = unpack(#A_3#23)
    #A_3_dim_0#25: int64 = #_A_3#24.shape[0]
    #A_3_dim_1#26: int64 = #_A_3#24.shape[1]
    #A_3_dim_2#27: int64 = #_A_3#24.shape[2]
    #_#A#0#29: BufferizedNDArray_f64_shape_i64_i64_strides_i64_i64 = unpack(##A#0#28)
    ##A#0_dim_0#30: int64 = #_#A#0#29.shape[0]
    ##A#0_dim_1#31: int64 = #_#A#0#29.shape[1]
    #_A_4#33: BufferizedNDArray_f64_shape_i64_i64_strides_i64_i64 = unpack(#A_4#32)
    #A_4_dim_0#34: int64 = #_A_4#33.shape[0]
    #A_4_dim_1#35: int64 = #_A_4#33.shape[1]
    #_A_5#37: BufferizedNDArray_f64_shape_i64_i64_strides_i64_i64 = unpack(#A_5#36)
    #A_5_dim_0#38: int64 = #_A_5#37.shape[0]
    #A_5_dim_1#39: int64 = #_A_5#37.shape[1]
    declare(#_A#16, 0, overwrite, [])
    loop(#i#40, Extent(0, #A_11_dim_0#9)):
        loop(#i_2#41, Extent(0, #A_11_dim_1#10)):
            increment(update(#_A#16, ['#i#40', '#i_2#41'], overwrite), unwrap(read(#_A_11#8, ['#i#40', '#i_2#41'])))
    freeze(#_A#16, overwrite)
    declare(#_A_2#20, 0, overwrite, [])
    loop(#i_3#42, Extent(0, #A_12_dim_0#13)):
        loop(#i_4#43, Extent(0, #A_12_dim_1#14)):
            increment(update(#_A_2#20, ['#i_3#42', '#i_4#43'], overwrite), unwrap(read(#_A_12#12, ['#i_3#42', '#i_4#43'])))
    freeze(#_A_2#20, overwrite)
    declare(#_A_3#24, 0, overwrite, [])
    loop(#i_8#44, Extent(0, #A_dim_0#17)):
        loop(#i_9#45, Extent(0, #A_2_dim_0#21)):
            loop(#i_15#46, Extent(0, #A_2_dim_1#22)):
                increment(update(#_A_3#24, ['#i_8#44', '#i_9#45', '#i_15#46'], overwrite), mul(unwrap(read(#_A#16, ['#i_8#44', '#i_9#45'])), unwrap(read(#_A_2#20, ['#i_9#45', '#i_15#46']))))
    freeze(#_A_3#24, overwrite)
    declare(#_#A#0#29, 0.0, add, [])
    loop(#i_16#47, Extent(0, #A_3_dim_0#25)):
        loop(#i_17#48, Extent(0, #A_3_dim_1#26)):
            loop(#i_18#49, Extent(0, #A_3_dim_2#27)):
                increment(update(#_#A#0#29, ['#i_16#47', '#i_18#49'], add), unwrap(read(#_A_3#24, ['#i_16#47', '#i_17#48', '#i_18#49'])))
    freeze(#_#A#0#29, add)
    declare(#_A_4#33, 0.0, overwrite, [])
    loop(#i_16#50, Extent(0, ##A#0_dim_0#30)):
        loop(#i_18#51, Extent(0, ##A#0_dim_1#31)):
            increment(update(#_A_4#33, ['#i_16#50', '#i_18#51'], overwrite), unwrap(read(#_#A#0#29, ['#i_16#50', '#i_18#51'])))
    freeze(#_A_4#33, overwrite)
    declare(#_A_5#37, 0.0, overwrite, [])
    loop(#i_16#52, Extent(0, #A_4_dim_0#34)):
        loop(#i_18#53, Extent(0, #A_4_dim_1#35)):
            increment(update(#_A_5#37, ['#i_16#52', '#i_18#53'], overwrite), unwrap(read(#_A_4#33, ['#i_16#52', '#i_18#53'])))
    freeze(#_A_5#37, overwrite)
    repack(#_A_11#8, #A_11#7)
    repack(#_A_12#12, #A_12#11)
    repack(#_A#16, #A#15)
    repack(#_A_2#20, #A_2#19)
    repack(#_A_3#24, #A_3#23)
    repack(#_#A#0#29, ##A#0#28)
    repack(#_A_4#33, #A_4#32)
    repack(#_A_5#37, #A_5#36)
    return make_tuple(#A_5#36)
```

</details>

---
Apart from this issue, in terms of debugging, how about passing an optional `debug_ctx` down the compilation stack where passes/stages can "log" arbitrary information, such as `prgm` before and after applying transformations?
This should make us more productive - no need to search for `print` statement debugging the kernel.