### PR TITLE
Implement extent proves and Spike looplet

### DIFF
--- a/src/finchlite/algebra/algebra.py
+++ b/src/finchlite/algebra/algebra.py
@@ -346,6 +346,8 @@ for op in (
     np.logical_and,
     np.logical_or,
     np.logical_xor,
+    max,
+    min,
 ):
     register_property(op, "__call__", "is_associative", lambda op: True)
 
@@ -363,6 +365,8 @@ for op in (
     np.logical_and,
     np.logical_or,
     np.logical_xor,
+    max,
+    min,
 ):
     register_property(op, "__call__", "is_commutative", lambda op: True)
 

--- a/src/finchlite/algebra/utils.py
+++ b/src/finchlite/algebra/utils.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Sequence
+from collections.abc import Collection, Iterable, Sequence
 
 
 def intersect(x1: Iterable, x2: Iterable) -> tuple:
@@ -11,6 +11,14 @@ def extend_uniqe(x1: Iterable, x2: Iterable) -> tuple:
 
 def is_subsequence(x1: Iterable, x2: Iterable) -> bool:
     return tuple(x1) == tuple(x for x in x2 if x in x1)
+
+
+def is_disjoint(x1: Iterable, x2: Iterable) -> bool:
+    return not any(x in x2 for x in x1)
+
+
+def all_unique(x: Collection) -> bool:
+    return len(set(x)) == len(x)
 
 
 def setdiff(x1: Iterable, x2: Iterable) -> tuple:

--- a/src/finchlite/autoschedule/compiler.py
+++ b/src/finchlite/autoschedule/compiler.py
@@ -15,7 +15,7 @@ from finchlite.symbolic.traversal import PostOrderDFS
 from .. import finch_logic as lgc
 from .. import finch_notation as ntn
 from ..algebra import make_tuple, overwrite
-from ..compile import Extent
+from ..compile.extents import Extent
 from ..finch_assembly import AssemblyLibrary
 from ..finch_logic import LogicLoader, compute_shape_vars
 from ..finch_notation import NotationInterpreter

--- a/src/finchlite/autoschedule/optimize.py
+++ b/src/finchlite/autoschedule/optimize.py
@@ -9,6 +9,7 @@ from finchlite.finch_logic.nodes import LogicExpression
 from finchlite.finch_logic.stages import LogicLoader
 from finchlite.symbolic import gensym
 
+from ..algebra.utils import intersect, setdiff
 from ..finch_logic import (
     Aggregate,
     Alias,
@@ -32,7 +33,6 @@ from ..symbolic import (
     PreWalk,
     Rewrite,
 )
-from ._utils import intersect, setdiff
 from .standardize import (
     concordize,
     flatten_plans,

--- a/src/finchlite/autoschedule/standardize.py
+++ b/src/finchlite/autoschedule/standardize.py
@@ -5,6 +5,7 @@ from finchlite.algebra.tensor import TensorFType
 from finchlite.finch_logic.nodes import LogicExpression, LogicNode
 
 from ..algebra import overwrite
+from ..algebra.utils import intersect, is_subsequence, setdiff, with_subsequence
 from ..finch_logic import (
     Aggregate,
     Alias,
@@ -31,7 +32,6 @@ from ..symbolic import (
     Rewrite,
     gensym,
 )
-from ._utils import intersect, is_subsequence, setdiff, with_subsequence
 from .normalize import normalize_names
 
 

--- a/src/finchlite/compile/extents.py
+++ b/src/finchlite/compile/extents.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from typing import Any
+
+from .. import finch_notation as ntn
+from .lower import Extent
+
+# TODO: move all extent classes and functions here
+
+
+class _CombineStyle(Enum):
+    UNION = 1
+    INTERSECT = 2
+
+
+def _combine_extents(ext_1: Extent, ext_2: Extent, style: _CombineStyle) -> Extent:
+    if style == _CombineStyle.UNION:
+        start_fn, end_fn = min, max
+    else:
+        start_fn, end_fn = max, min
+
+    start_1, start_2 = ext_1.ftype.get_start(ext_1), ext_2.ftype.get_start(ext_2)
+    end_1, end_2 = ext_1.ftype.get_end(ext_1), ext_2.ftype.get_end(ext_2)
+    return Extent(
+        start=ntn.Call(ntn.Literal(start_fn), (start_1, end_1)),
+        end=ntn.Call(ntn.Literal(end_fn), (start_2, end_2)),
+    )
+
+
+def intersect_extents(ext_1: Extent, ext_2: Extent) -> Extent:
+    return _combine_extents(ext_1, ext_2, _CombineStyle.INTERSECT)
+
+
+def union_extents(ext_1: Extent, ext_2: Extent) -> Extent:
+    return _combine_extents(ext_1, ext_2, _CombineStyle.UNION)
+
+
+def get_start(ext: Extent) -> Any:
+    return ext.ftype.get_start(ext)
+
+
+def get_end(ext: Extent) -> Any:
+    return ext.ftype.get_end(ext)
+
+
+def get_unit(ext: Extent) -> Any:
+    return ext.ftype.get_unit(ext)

--- a/src/finchlite/compile/looplets.py
+++ b/src/finchlite/compile/looplets.py
@@ -1,12 +1,14 @@
+import operator
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from finchlite.compile.lower import LoopletPass, SingletonExtentFType
-
 from .. import finch_assembly as asm
 from .. import finch_notation as ntn
+from ..compile.extents import Extent, get_end, get_start, get_unit
+from ..compile.lower import LoopletPass, SingletonExtentFType
+from ..finch_notation.proves import prove
 from ..symbolic import PostWalk
 
 
@@ -77,12 +79,59 @@ class Spike:
     body: Any
     tail: Any
 
+    @property
+    def pass_request(self):
+        return SpikePass()
+
+    def truncate(self, ext_1, ext_2):
+        if prove(
+            ntn.Call(
+                ntn.Literal(operator.ge),
+                (
+                    ntn.Call(
+                        ntn.Literal(operator.sub), (get_end(ext_1), get_unit(ext_1))
+                    ),
+                    get_end(ext_2),
+                ),
+            )
+        ):
+            return Run(self.body)
+        if prove(ntn.Call(ntn.Literal(operator.eq), (get_end(ext_1), get_end(ext_2)))):
+            return self
+        raise NotImplementedError
+
 
 @dataclass
 class SpikePass(LoopletPass):
     @property
     def priority(self):
         return 0
+
+    def __call__(self, ctx, idx, ext, body):
+        def spike_body(node):
+            match node:
+                case ntn.Access(Spike(body, _), mode, (j, *idxs)) if j == idx:
+                    return ntn.Access(body(ctx), mode, (j, *idxs))
+
+        body_body = PostWalk(spike_body)(body)
+        body_ctx = ctx.scope()
+        body_ext = Extent(
+            get_start(ext),
+            asm.Call(asm.Literal(operator.sub), (get_end(ext), get_unit(ext))),
+        )
+        body_ctx(body_ext, body_body)
+
+        def spike_tail(node):
+            match node:
+                case ntn.Access(Spike(_, tail), mode, (j, *idxs)) if j == idx:
+                    return ntn.Access(tail(ctx), mode, (j, *idxs))
+
+        tail_body = PostWalk(spike_tail)(body)
+        tail_ctx = ctx.scope()
+        tail_ext = SingletonExtentFType.stack(get_end(ext))
+        tail_ctx(tail_ext, tail_body)
+
+        ctx.exec(asm.Block((*body_ctx.emit(), *tail_ctx.emit())))
 
 
 @dataclass

--- a/src/finchlite/compile/lower.py
+++ b/src/finchlite/compile/lower.py
@@ -203,6 +203,9 @@ class ExtentFType(AssemblyStructFType):
             case _:
                 return asm.GetAttr(ext, asm.Literal("end"))
 
+    def get_unit(self, ext):
+        return self.start(1)
+
     def lower_loop(self, ctx, idx, ext, body):
         """
         Lower a loop with the given index and body.

--- a/src/finchlite/finch_notation/proves.py
+++ b/src/finchlite/finch_notation/proves.py
@@ -1,0 +1,223 @@
+from collections.abc import Callable
+from collections.abc import Sequence as Seq
+from functools import partial
+from operator import add, eq, ge, le
+
+from ..algebra import is_associative, is_idempotent
+from ..algebra.utils import all_unique, intersect, is_disjoint, setdiff
+from ..symbolic import Chain, Fixpoint, Memo, PreWalk, Rewrite
+from .nodes import Cached, Call, NotationNode
+from .nodes import Literal as L
+
+NN = NotationNode
+
+
+def _find_first_call(
+    args: Seq[NN], op: Callable
+) -> tuple[Seq[NN], Seq[NN], Seq[NN]] | None:
+    for i, arg in enumerate(args):
+        if isinstance(arg, Call) and arg.op == L(op):
+            return args[:i], arg.args, args[i + 1 :]
+    return None
+
+
+def rule_all_literals(ex):
+    """All args are literals."""
+    match ex:
+        case Call(L(op), args):
+            lit_args = []
+            for arg in args:
+                match arg:
+                    case L(val):
+                        lit_args.append(val)
+                    case _:
+                        return None
+            return L(op(*lit_args))
+
+
+def rule_idempotent_unique(ex):
+    """Remove duplicates from idempotent op."""
+    match ex:
+        case Call(L(op), args) if is_idempotent(op) and not all_unique(args):
+            return Call(L(op), tuple(set(args)))
+
+
+def rule_associative_flatten(ex):
+    """Flatten nested associative ops."""
+    match ex:
+        case Call(L(op), args) if (
+            is_associative(op) and (found := _find_first_call(args, op)) is not None
+        ):
+            before, call_args, after = found
+            return Call(L(op), (*before, *call_args, *after))
+
+
+def rule_equal_same(ex):
+    """Match eq(a, a) => True."""
+    match ex:
+        case Call(L(op), (a, b)) if op == eq and a == b:
+            return L(True)
+
+
+def rule_ge(ex):
+    """Transform ge(a, b) => eq(a, max(a, b))."""
+    match ex:
+        case Call(L(op), (a, b)) if op == ge:
+            return Call(L(eq), (a, Call(L(max), (a, b))))
+
+
+def rule_le(ex):
+    """Transform le(a, b) => eq(max(a, b), b)."""
+    match ex:
+        case Call(L(op), (a, b)) if op == le:
+            return Call(L(eq), (Call(L(max), (a, b)), b))
+
+
+def rule_add_with(ex, func):
+    """
+    Distribute max/min over add.
+
+    ```
+    call(+, ~a..., call(max/min, ~b...), ~c...) =>
+        call(max/min, map(x -> call(+, a..., x, c...), b)...))
+    ```
+    """
+    match ex:
+        case Call(L(op), args) if (
+            op == add and (found := _find_first_call(args, func)) is not None
+        ):
+            before, call_args, after = found
+            return Call(
+                L(func), tuple(Call(L(add), (*before, ca, *after)) for ca in call_args)
+            )
+
+
+rule_add_with_max = partial(rule_add_with, func=max)
+rule_add_with_min = partial(rule_add_with, func=min)
+
+
+def rule_disjoint_nested(ex, func1, func2):
+    """Handle nested max/min in min/max."""
+    match ex:
+        case Call(L(op), args) if (
+            op == func1 and (found := _find_first_call(args, func2)) is not None
+        ):
+            before, call_args, after = found
+            if (found2 := _find_first_call(call_args, func1)) is not None:
+                before2, call_args2, after2 = found2
+                if not is_disjoint(call_args2, before) or not is_disjoint(
+                    call_args2, after
+                ):
+                    return Call(
+                        L(func1),
+                        (
+                            *before,
+                            Call(
+                                L(func2),
+                                (
+                                    *before2,
+                                    *setdiff(call_args2, before + after),
+                                    *after2,
+                                ),
+                            ),
+                            *after,
+                        ),
+                    )
+            return None
+
+
+rule_disjoint_nested_max_min = partial(rule_disjoint_nested, func1=max, func2=min)
+rule_disjoint_nested_min_max = partial(rule_disjoint_nested, func1=min, func2=max)
+
+
+def rule_disjoint_flat_single(ex, func1, func2):
+    """
+    Remove min/max from max/min when disjoint.
+    """
+    match ex:
+        case Call(L(op), args) if (
+            op == func1 and (found := _find_first_call(args, func2)) is not None
+        ):
+            before, call_args, after = found
+            if not is_disjoint(before, call_args) or not is_disjoint(call_args, after):
+                return Call(L(func1), (*before, *after))
+            return None
+
+
+rule_disjoint_flat_single_max_min = partial(
+    rule_disjoint_flat_single, func1=max, func2=min
+)
+rule_disjoint_flat_single_min_max = partial(
+    rule_disjoint_flat_single, func1=min, func2=max
+)
+
+
+def rule_disjoint_flat_pair(ex, func1, func2):
+    """Handle two mins/maxes in max/min."""
+    match ex:
+        case Call(L(op), args) if (
+            op == func1 and (found := _find_first_call(args, func2)) is not None
+        ):
+            before, call_args, after = found
+            if (found2 := _find_first_call(after, func2)) is not None:
+                before2, call_args2, after2 = found2
+                if not is_disjoint(call_args, call_args2):
+                    intersection = intersect(call_args, call_args2)
+                    diff1 = setdiff(call_args, call_args2)
+                    diff2 = setdiff(call_args2, call_args)
+                    arg = Call(
+                        L(func2),
+                        (
+                            *intersection,
+                            Call(
+                                L(func1), (Call(L(func2), diff1), Call(L(func2), diff2))
+                            ),
+                        ),
+                    )
+                    return Call(L(func1), (*before, arg, *before2, *after2))
+            return None
+
+
+rule_disjoint_flat_pair_max_min = partial(rule_disjoint_flat_pair, func1=max, func2=min)
+rule_disjoint_flat_pair_min_max = partial(rule_disjoint_flat_pair, func1=min, func2=max)
+
+
+def prove_rules():
+    return [
+        rule_all_literals,
+        rule_idempotent_unique,
+        rule_associative_flatten,
+        rule_equal_same,
+        rule_ge,
+        rule_le,
+        rule_add_with_max,
+        rule_add_with_min,
+        rule_disjoint_nested_max_min,
+        rule_disjoint_nested_min_max,
+        rule_disjoint_flat_single_max_min,
+        rule_disjoint_flat_single_min_max,
+        rule_disjoint_flat_pair_max_min,
+        rule_disjoint_flat_pair_min_max,
+    ]
+
+
+def prove(root: NotationNode):
+    def rule_extract_cached(ex):
+        match ex:
+            case Cached(_, L(val)):
+                return val
+
+    root = Rewrite(PreWalk(rule_extract_cached))(root)
+
+    prove_cache: dict = {}
+
+    # TODO: rename rewrite
+
+    res = Rewrite(Fixpoint(PreWalk(Memo(Fixpoint(Chain(prove_rules())), prove_cache))))(
+        root
+    )
+    match res:
+        case L(val):
+            return val
+        case _:
+            return False

--- a/src/finchlite/symbolic/__init__.py
+++ b/src/finchlite/symbolic/__init__.py
@@ -5,6 +5,7 @@ from .gensym import gensym
 from .rewriters import (
     Chain,
     Fixpoint,
+    Memo,
     PostWalk,
     PreWalk,
     Rewrite,
@@ -26,6 +27,7 @@ __all__ = [
     "FType",
     "FTyped",
     "Fixpoint",
+    "Memo",
     "NamedTerm",
     "Namespace",
     "PostOrderDFS",

--- a/src/finchlite/symbolic/rewriters.py
+++ b/src/finchlite/symbolic/rewriters.py
@@ -11,8 +11,7 @@ Classes:
         returned if the rewriter produces no changes.
     PreWalk: Recursively rewrites each node in a term using a pre-order traversal.
     PostWalk: Recursively rewrites each node in a term using a post-order traversal.
-    Chain: Applies a sequence of rewriters to a term, stopping when a rewriter
-        produces a change.
+    Chain: Applies a sequence of rewriters to a term.
     Fixpoint: Repeatedly applies a rewriter to a term until no further changes
         are made.
     Prestep: Recursively rewrites each node in a term, stopping if the rewriter

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -1,0 +1,202 @@
+from operator import add, eq, ge, le
+
+from finchlite.finch_notation.nodes import Call
+from finchlite.finch_notation.nodes import Literal as L
+from finchlite.finch_notation.proves import (
+    rule_add_with_max,
+    rule_add_with_min,
+    rule_all_literals,
+    rule_associative_flatten,
+    rule_disjoint_flat_pair_max_min,
+    rule_disjoint_flat_pair_min_max,
+    rule_disjoint_flat_single_max_min,
+    rule_disjoint_flat_single_min_max,
+    rule_disjoint_nested_max_min,
+    rule_disjoint_nested_min_max,
+    rule_equal_same,
+    rule_ge,
+    rule_idempotent_unique,
+    rule_le,
+)
+
+# NOTE: These test cases were AI generated based on proves.py.
+
+
+def test_rule_all_literals():
+    # Simple case: add(1, 2) => 3
+    expr = Call(L(add), (L(1), L(2)))
+    result = rule_all_literals(expr)
+    assert result == L(3)
+
+    # Should not match non-literals
+    expr = Call(L(add), (L(1), Call(L(max), (L(2), L(3)))))
+    result = rule_all_literals(expr)
+    assert result is None
+
+
+def test_rule_idempotent_unique():
+    # max(a, a, b) => max(a, b)
+    a, b = L("a"), L("b")
+    expr = Call(L(max), (a, a, b))
+    result = rule_idempotent_unique(expr)
+    assert isinstance(result, Call)
+    assert result.op == L(max)
+    assert set(result.args) == {a, b}
+
+    # Should not match when all unique
+    expr = Call(L(max), (a, b))
+    result = rule_idempotent_unique(expr)
+    assert result is None
+
+
+def test_rule_associative_flatten():
+    # max(a, max(b, c)) => max(a, b, c)
+    a, b, c = L("a"), L("b"), L("c")
+    expr = Call(L(max), (a, Call(L(max), (b, c))))
+    result = rule_associative_flatten(expr)
+    assert result == Call(L(max), (a, b, c))
+
+    # Should not match when no nested call
+    expr = Call(L(max), (a, b))
+    result = rule_associative_flatten(expr)
+    assert result is None
+
+
+def test_rule_equal_same():
+    # eq(a, a) => True
+    a = L("a")
+    expr = Call(L(eq), (a, a))
+    result = rule_equal_same(expr)
+    assert result == L(True)
+
+    # Should not match when different
+    b = L("b")
+    expr = Call(L(eq), (a, b))
+    result = rule_equal_same(expr)
+    assert result is None
+
+
+def test_rule_ge():
+    # ge(a, b) => eq(a, max(a, b))
+    a, b = L("a"), L("b")
+    expr = Call(L(ge), (a, b))
+    result = rule_ge(expr)
+    assert result == Call(L(eq), (a, Call(L(max), (a, b))))
+
+
+def test_rule_le():
+    # le(a, b) => eq(max(a, b), b)
+    a, b = L("a"), L("b")
+    expr = Call(L(le), (a, b))
+    result = rule_le(expr)
+    assert result == Call(L(eq), (Call(L(max), (a, b)), b))
+
+
+def test_rule_add_with_max():
+    # add(a, max(b, c)) => max(add(a, b), add(a, c))
+    a, b, c = L("a"), L("b"), L("c")
+    expr = Call(L(add), (a, Call(L(max), (b, c))))
+    result = rule_add_with_max(expr)
+    assert result == Call(L(max), (Call(L(add), (a, b)), Call(L(add), (a, c))))
+
+    # Should not match when no max
+    expr = Call(L(add), (a, b))
+    result = rule_add_with_max(expr)
+    assert result is None
+
+
+def test_rule_add_with_min():
+    # add(a, min(b, c)) => min(add(a, b), add(a, c))
+    a, b, c = L("a"), L("b"), L("c")
+    expr = Call(L(add), (a, Call(L(min), (b, c))))
+    result = rule_add_with_min(expr)
+    assert result == Call(L(min), (Call(L(add), (a, b)), Call(L(add), (a, c))))
+
+    # Should not match when no min
+    expr = Call(L(add), (a, b))
+    result = rule_add_with_min(expr)
+    assert result is None
+
+
+def test_rule_disjoint_nested_max_min():
+    # max(a, min(b, max(a, c))) with non-disjoint sets
+    a, b, c = L("a"), L("b"), L("c")
+    expr = Call(L(max), (a, Call(L(min), (b, Call(L(max), (a, c))))))
+    result = rule_disjoint_nested_max_min(expr)
+    # Should return max(a, min(b, c)) since 'a' appears in both outer and inner max
+    assert result == Call(L(max), (a, Call(L(min), (b, c))))
+
+
+def test_rule_disjoint_nested_min_max():
+    # min(a, max(b, min(a, c))) with non-disjoint sets
+    a, b, c = L("a"), L("b"), L("c")
+    expr = Call(L(min), (a, Call(L(max), (b, Call(L(min), (a, c))))))
+    result = rule_disjoint_nested_min_max(expr)
+    # Should return min(a, max(b, c)) since 'a' appears in both outer and inner min
+    assert result == Call(L(min), (a, Call(L(max), (b, c))))
+
+
+def test_rule_disjoint_flat_single_max_min():
+    # max(a, min(a, b)) with non-disjoint sets => max(a)
+    a, b = L("a"), L("b")
+    expr = Call(L(max), (a, Call(L(min), (a, b))))
+    result = rule_disjoint_flat_single_max_min(expr)
+    # Since 'a' is in both max args and min args (not disjoint), min is removed
+    assert result == Call(L(max), (a,))
+
+    # Should not match when disjoint
+    c = L("c")
+    expr = Call(L(max), (a, Call(L(min), (b, c))))
+    result = rule_disjoint_flat_single_max_min(expr)
+    assert result is None
+
+
+def test_rule_disjoint_flat_single_min_max():
+    # min(a, max(a, b)) with non-disjoint sets => min(a)
+    a, b = L("a"), L("b")
+    expr = Call(L(min), (a, Call(L(max), (a, b))))
+    result = rule_disjoint_flat_single_min_max(expr)
+    # Since 'a' is in both min args and max args (not disjoint), max is removed
+    assert result == Call(L(min), (a,))
+
+    # Should not match when disjoint
+    c = L("c")
+    expr = Call(L(min), (a, Call(L(max), (b, c))))
+    result = rule_disjoint_flat_single_min_max(expr)
+    assert result is None
+
+
+def test_rule_disjoint_flat_pair_max_min():
+    # max(min(a, b), min(a, c)) with non-disjoint mins
+    a, b, c = L("a"), L("b"), L("c")
+    expr = Call(L(max), (Call(L(min), (a, b)), Call(L(min), (a, c))))
+    result = rule_disjoint_flat_pair_max_min(expr)
+    # Should create nested structure with intersection and differences
+    assert result == Call(
+        L(max),
+        (Call(L(min), (a, Call(L(max), (Call(L(min), (b,)), Call(L(min), (c,)))))),),
+    )
+
+    # Should not match when disjoint
+    d = L("d")
+    expr = Call(L(max), (Call(L(min), (a, b)), Call(L(min), (c, d))))
+    result = rule_disjoint_flat_pair_max_min(expr)
+    assert result is None
+
+
+def test_rule_disjoint_flat_pair_min_max():
+    # min(max(a, b), max(a, c)) with non-disjoint maxs
+    a, b, c = L("a"), L("b"), L("c")
+    expr = Call(L(min), (Call(L(max), (a, b)), Call(L(max), (a, c))))
+    result = rule_disjoint_flat_pair_min_max(expr)
+    # Should create nested structure with intersection and differences
+    assert result == Call(
+        L(min),
+        (Call(L(max), (a, Call(L(min), (Call(L(max), (b,)), Call(L(max), (c,)))))),),
+    )
+
+    # Should not match when disjoint
+    d = L("d")
+    expr = Call(L(min), (Call(L(max), (a, b)), Call(L(max), (c, d))))
+    result = rule_disjoint_flat_pair_min_max(expr)
+    assert result is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from finchlite.autoschedule._utils import intersect, is_subsequence, with_subsequence
+from finchlite.algebra.utils import intersect, is_subsequence, with_subsequence
 
 
 def test_intersect(tp_0, tp_1, tp_2, tp_3):


### PR DESCRIPTION
This PR:
- Introduces `proves.py` with AI generated test cases,
- Starts `extents.py` file,
- Adds implementation for Spike looplet pass.